### PR TITLE
Added vanish compatibility to /vlist

### DIFF
--- a/src/main/java/su/plo/voice/commands/VoiceList.java
+++ b/src/main/java/su/plo/voice/commands/VoiceList.java
@@ -5,9 +5,11 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.checkerframework.checker.units.qual.A;
 import su.plo.voice.PlasmoVoice;
 import su.plo.voice.socket.SocketServerUDP;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -19,9 +21,19 @@ public class VoiceList implements CommandExecutor {
                 .map(Player::getName)
                 .collect(Collectors.toList());
 
+        List<String> clientsToRemove = new ArrayList<>();
+        if(sender instanceof Player) {
+            for (Player currentPlayer : Bukkit.getOnlinePlayers()) {
+                if (!((Player) sender).canSee(currentPlayer)) {
+                    clientsToRemove.add(currentPlayer.getName());
+                }
+            }
+        }
+        clients.removeAll(clientsToRemove);
+
         sender.sendMessage(PlasmoVoice.getInstance().getMessagePrefix("list")
                 .replace("{count}", String.valueOf(clients.size()))
-                .replace("{online_players}", String.valueOf(Bukkit.getOnlinePlayers().size()))
+                .replace("{online_players}", String.valueOf(Bukkit.getOnlinePlayers().size() - clientsToRemove.size()))
                 .replace("{players}", String.join(", ", clients)));
         return true;
     }

--- a/src/main/java/su/plo/voice/commands/VoiceList.java
+++ b/src/main/java/su/plo/voice/commands/VoiceList.java
@@ -5,7 +5,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.checkerframework.checker.units.qual.A;
 import su.plo.voice.PlasmoVoice;
 import su.plo.voice.socket.SocketServerUDP;
 


### PR DESCRIPTION
Now players who can't be seen by the player who is executing the /vlist command won't be shown to them
In other words, fixed an issue where /vlist could be used to expose vanished players who were using the mod

Tested with VanishNoPacket, SuperVanish, and EssentialsX

Partially adresses #26 