### PR TITLE
[UI] Activation threshold can no longer be changed when Push-to-talk

### DIFF
--- a/common/src/main/java/su/plo/voice/client/gui/tabs/GeneralTabWidget.java
+++ b/common/src/main/java/su/plo/voice/client/gui/tabs/GeneralTabWidget.java
@@ -158,18 +158,21 @@ public class GeneralTabWidget extends TabWidget {
                 })
         );
 
+        MicrophoneThresholdWidget activationThreshold = new MicrophoneThresholdWidget(0, 0, 97, true, parent);
         String[] activations = new String[]{"gui.plasmo_voice.general.activation.ptt", "gui.plasmo_voice.general.activation.voice"};
         Button voiceActivation = new Button(0, 0, 97, 20, onOff(VoiceClient.getClientConfig().voiceActivation.get()
                         && !VoiceClient.getServerConfig().isVoiceActivationDisabled(),
                 activations),
                 button -> {
                     VoiceClient.getClientConfig().voiceActivation.invert();
-                    button.setMessage(onOff(VoiceClient.getClientConfig().voiceActivation.get()
-                                    && !VoiceClient.getServerConfig().isVoiceActivationDisabled(),
-                            activations));
+                    boolean enableVoiceActivation = VoiceClient.getClientConfig().voiceActivation.get()
+                            && !VoiceClient.getServerConfig().isVoiceActivationDisabled();
+                    button.setMessage(onOff(enableVoiceActivation, activations));
+                    activationThreshold.active = enableVoiceActivation;
                 });
 
         voiceActivation.active = !VoiceClient.getServerConfig().isVoiceActivationDisabled();
+        activationThreshold.active = VoiceClient.getClientConfig().voiceActivation.get();
 
         this.addEntry(new CategoryEntry(new TranslatableComponent("gui.plasmo_voice.general.activation")));
         this.addEntry(new OptionEntry(
@@ -185,7 +188,7 @@ public class GeneralTabWidget extends TabWidget {
         );
         this.addEntry(new OptionEntry(
                 new TranslatableComponent("gui.plasmo_voice.general.activation.threshold"),
-                new MicrophoneThresholdWidget(0, 0, 97, true, parent),
+                activationThreshold,
                 VoiceClient.getClientConfig().voiceActivationThreshold,
                 TextUtils.multiLine("gui.plasmo_voice.general.activation.threshold.tooltip", 8),
                 (button, element) -> {


### PR DESCRIPTION
![type is push-to-talk](https://user-images.githubusercontent.com/34268371/137833003-d1c69b50-9127-4e0e-a26a-243f872c7fb8.png)
![type is voice ](https://user-images.githubusercontent.com/34268371/137833019-353df9b1-2e9a-4534-8985-dc147787de1a.png)

It behaves like a direction source and an angle. You can't change it with the slider, but you can press Reset or Icon.

---
Current Direction sources behavior:

![disable direction source](https://user-images.githubusercontent.com/34268371/137833314-7ebd7811-8f91-4db0-ad51-30d520acc76f.png)
![enable direction source](https://user-images.githubusercontent.com/34268371/137833285-69b9418a-97cc-45cb-80a6-a17eeddec3f7.png)
