### PR TITLE
Fix gui.plasmo_voice.title not being reflected

### DIFF
--- a/common/src/main/resources/assets/plasmo_voice/lang/en_us.json
+++ b/common/src/main/resources/assets/plasmo_voice/lang/en_us.json
@@ -18,7 +18,7 @@
     "gui.plasmo_voice.on": "On",
     "gui.plasmo_voice.off": "Off",
 
-    "gui.plasmo_voice.title": "Settings",
+    "gui.plasmo_voice.title": "%s Settings",
 
 
     "gui.plasmo_voice.toggle.microphone": "Toggle microphone",

--- a/common/src/main/resources/assets/plasmo_voice/lang/it_it.json
+++ b/common/src/main/resources/assets/plasmo_voice/lang/it_it.json
@@ -18,7 +18,7 @@
     "gui.plasmo_voice.on": "On",
     "gui.plasmo_voice.off": "Off",
 
-    "gui.plasmo_voice.title": "Impostazioni",
+    "gui.plasmo_voice.title": "Impostazioni %s",
 
 
     "gui.plasmo_voice.toggle.microphone": "Abilita il microfono",


### PR DESCRIPTION
https://github.com/plasmoapp/plasmo-voice/blob/cbaf6462973cf52b11c57c95ae96174b8f968894/common/src/main/java/su/plo/voice/client/gui/VoiceSettingsScreen.java#L87-L99

`gui.plasmo_voice.title` requires `%s`, but it wasn't written in `en_us.json`. So It was using the default value ​​in `.java`.

## Changes

### Current

![image](https://user-images.githubusercontent.com/34268371/137952037-aca01bd5-0507-4ad2-acac-24d4eb72608b.png)

### Fixed

![image](https://user-images.githubusercontent.com/34268371/137953794-5afe709e-4f59-4f26-abb7-ecca95c098fd.png)

## Other languages

| Code | Status |
|---|---|
| en_us | #108 (This) |
| it_it | #108 (This) |
| ja_jp | #107 |
| ru_ru | Already Fixed |
