### PR TITLE
Add IllegalArgumentException to ignored exceptions in SocketServerUDP

### DIFF
--- a/src/main/java/su/plo/voice/socket/SocketServerUDP.java
+++ b/src/main/java/su/plo/voice/socket/SocketServerUDP.java
@@ -103,7 +103,7 @@ public class SocketServerUDP extends Thread {
                 synchronized (this.queue) {
                     this.queue.notify();
                 }
-            } catch (IOException | InstantiationException | IllegalStateException e) { // bad packet? just ignore it 4HEad
+            } catch (IOException | InstantiationException | IllegalStateException | IllegalArgumentException e) { // bad packet? just ignore it 4HEad
                 if (PlasmoVoice.getInstance().getConfig().getBoolean("debug")) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
Fixes console spam if [`UUID.fromString(String)` call fails](https://github.com/plasmoapp/plasmo-voice/blob/3ed9ecdee387275bde42add306f2f1c74417e86e/src/main/java/su/plo/voice/common/packets/udp/VoiceServerPacket.java#L43) because packet is corrupted or invalid.

* Fixes #146 
* Fixes #158

_such a big pr_