### PR TITLE
Continued API update (and other changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ For methods see this [class](https://github.com/plasmoapp/plasmo-voice/tree/main
 
 For events see this [package](https://github.com/plasmoapp/plasmo-voice/tree/main-spigot/src/main/java/su/plo/voice/events)
 
+All of the javadocs are accessible and written simply and understandably!
+
 ## Examples of API usage
 
 Example #1: Full class with simple remote voice chat, linking players together by holding an iron ingot.
@@ -87,8 +89,7 @@ public final class APIExample extends JavaPlugin implements Listener {
     }
 
     @Override
-    public void onDisable() {
-    }
+    public void onDisable() {}
 
     @EventHandler
     public void onSpeak(PlayerSpeakEvent event) {
@@ -110,5 +111,28 @@ Example #2: Send "Hey, you're talking!" to player which is started talking.
 @EventHandler
 public void onStartSpeak(PlayerStartSpeakEvent event) {
     event.getPlayer().sendMessage("Hey, you're talking!");
+}
+```
+
+Example #3: Send "Use Fabric instead of Forge!" to player is joined with Forge.
+
+```java
+@EventHandler
+public void onJoin(PlayerJoinEvent event) {
+    if (api.getPlayerModLoader() == null) return;
+    if (api.getPlayerModLoader().equals("forge")) {
+        event.getPlayer().sendMessage("Use Fabric instead of Forge!");
+    }
+}
+```
+
+Example #4: Mute a player for 10 minutes without informing the player and for no reason if he sends a message that starts with "You're stupid!"
+
+```java
+@EventHandler
+public void onChat(AsyncChatEvent event) {
+    if (PlainComponentSerializer.plain().serialize(event.originalMessage()).startsWith("You're stupid!")) {
+        api.mute(event.getPlayer().getUniqueId(), 10, PlasmoVoiceAPI.DurationUnit.MINUTES, null, false);
+    }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -97,8 +97,10 @@ public final class APIExample extends JavaPlugin implements Listener {
         event.setCancelled(true);
         for (Player player : api.getConnectedPlayers()) {
             if (!player.getEquipment().getItemInMainHand().getType().equals(Material.IRON_INGOT)) continue;
-            VoiceServerPacket pa = (VoiceServerPacket) event.getPacket();
-            VoiceServerPacket packet = new VoiceServerPacket(pa.getData(), player.getUniqueId(), pa.getSequenceNumber(), pa.getDistance());
+            VoiceServerPacket packet = new VoiceServerPacket(
+                    event.getPacket().getData(), player.getUniqueId(),
+                    event.getPacket().getSequenceNumber(), event.getPacket().getDistance()
+            );
             api.sendVoicePacketToPlayer(packet, player);
         }
     }

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For events see this [package](https://github.com/plasmoapp/plasmo-voice/tree/mai
 
 ## Examples of API usage
 
-Example #1: Full class with simple Player-to-Player voice chat, linking players together by holding an iron ingot.
+Example #1: Full class with simple remote voice chat, linking players together by holding an iron ingot.
 
 ```java
 public final class APIExample extends JavaPlugin implements Listener {

--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ public final class APIExample extends JavaPlugin implements Listener {
         event.setCancelled(true);
         for (Player player : api.getConnectedPlayers()) {
             if (!player.getEquipment().getItemInMainHand().getType().equals(Material.IRON_INGOT)) continue;
-            api.sendVoicePacketToPlayer(event.getPacket(), player);
+            VoiceServerPacket pa = (VoiceServerPacket) event.getPacket();
+            VoiceServerPacket packet = new VoiceServerPacket(pa.getData(), player.getUniqueId(), pa.getSequenceNumber(), pa.getDistance());
+            api.sendVoicePacketToPlayer(packet, player);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ PlasmoVoiceAPI api = PlasmoVoice.getInstance();
 
 ## Methods and Events
 
-For methods see this class: [PlasmoVoiceAPI](https://github.com/plasmoapp/plasmo-voice/tree/main-spigot/src/main/java/su/plo/voice/PlasmoVoiceAPI.java)
+For methods see this [class](https://github.com/plasmoapp/plasmo-voice/tree/main-spigot/src/main/java/su/plo/voice/PlasmoVoiceAPI.java)
 
 For events see this [package](https://github.com/plasmoapp/plasmo-voice/tree/main-spigot/src/main/java/su/plo/voice/events)
 
 ## Examples of API usage
 
-Example #1: Remote voice chat between players, linking players together by holding an iron ingot.
+Example #1: Full class with simple Player-to-Player voice chat, linking players together by holding an iron ingot.
 
 ```java
 public final class APIExample extends JavaPlugin implements Listener {
@@ -99,5 +99,14 @@ public final class APIExample extends JavaPlugin implements Listener {
             api.sendVoicePacketToPlayer(event.getPacket(), player);
         }
     }
+}
+```
+
+Example #2: Send "Hey, you're talking!" to player which is started talking.
+
+```java
+@EventHandler
+public void onStartSpeak(PlayerStartSpeakEvent event) {
+    event.getPlayer().sendMessage("Hey, you're talking!");
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.0.2</version>
                 <configuration>
-                    <finalName>plasmovoice-server-${version}</finalName>
+                    <finalName>plasmovoice-server-${project.version}</finalName>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/su/plo/voice/PlasmoVoice.java
+++ b/src/main/java/su/plo/voice/PlasmoVoice.java
@@ -229,7 +229,8 @@ public final class PlasmoVoice extends JavaPlugin implements PlasmoVoiceAPI {
                 fadeDivisor,
                 priorityFadeDivisor,
                 config.getBoolean("client_mod_required"),
-                clientModCheckTimeout
+                clientModCheckTimeout,
+                config.getBoolean("disable_logs")
         );
     }
 

--- a/src/main/java/su/plo/voice/PlasmoVoice.java
+++ b/src/main/java/su/plo/voice/PlasmoVoice.java
@@ -406,6 +406,14 @@ public final class PlasmoVoice extends JavaPlugin implements PlasmoVoiceAPI {
         }
     }
 
+    /**
+     * @return list of muted players uuids
+     */
+    @Override
+    public List<UUID> getMutedPlayersUUIDs() {
+        return Collections.list(muted.keys());
+    }
+
     @Override
     public Map<UUID, ServerMutedEntity> getMutedMap() {
         return muted;

--- a/src/main/java/su/plo/voice/PlasmoVoice.java
+++ b/src/main/java/su/plo/voice/PlasmoVoice.java
@@ -336,12 +336,12 @@ public final class PlasmoVoice extends JavaPlugin implements PlasmoVoiceAPI {
             return false;
         }
 
-        ServerMutedEntity muted = PlasmoVoice.muted.get(player.getUniqueId());
-        if (muted == null) {
+        ServerMutedEntity serverMuted = PlasmoVoice.muted.get(player.getUniqueId());
+        if (serverMuted == null) {
             return false;
         }
 
-        PlasmoVoice.muted.remove(muted.getUuid());
+        muted.remove(serverMuted.getUuid());
 
         Player onlinePlayer = Bukkit.getPlayer(player.getUniqueId());
         if (onlinePlayer != null) {
@@ -418,9 +418,6 @@ public final class PlasmoVoice extends JavaPlugin implements PlasmoVoiceAPI {
         }
     }
 
-    /**
-     * @return list of muted players uuids
-     */
     @Override
     public List<UUID> getMutedPlayersUUIDs() {
         return Collections.list(muted.keys());
@@ -462,6 +459,21 @@ public final class PlasmoVoice extends JavaPlugin implements PlasmoVoiceAPI {
                 .stream()
                 .map(client -> client.getPlayer().getUniqueId())
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public int getDefaultDistance() {
+        return voiceConfig.getDefaultDistance();
+    }
+
+    @Override
+    public int getMaxDistance() {
+        return voiceConfig.getMaxDistance();
+    }
+
+    @Override
+    public short getMaxPriorityDistance() {
+        return voiceConfig.getMaxPriorityDistance();
     }
 
     @Override

--- a/src/main/java/su/plo/voice/PlasmoVoice.java
+++ b/src/main/java/su/plo/voice/PlasmoVoice.java
@@ -16,6 +16,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.ServicePriority;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import su.plo.voice.commands.*;
 import su.plo.voice.common.packets.Packet;
@@ -183,14 +184,12 @@ public final class PlasmoVoice extends JavaPlugin implements PlasmoVoiceAPI {
         }
 
         List<Integer> distances = config.getIntegerList("distances");
-        if (distances.size() == 0) {
+        if (distances.isEmpty()) {
             voiceLogger.warning("Distances cannot be empty");
             return;
         }
         int defaultDistance = config.getInt("default_distance");
-        if (defaultDistance == 0) {
-            defaultDistance = distances.get(0);
-        } else if (!distances.contains(defaultDistance)) {
+        if (defaultDistance == 0 || !distances.contains(defaultDistance)) {
             defaultDistance = distances.get(0);
         }
 
@@ -363,7 +362,8 @@ public final class PlasmoVoice extends JavaPlugin implements PlasmoVoiceAPI {
     }
 
     @Override
-    public boolean sendVoicePacketToPlayer(Packet packet, Player recipient) {
+    public boolean sendVoicePacketToPlayer(@NotNull Packet packet, @NotNull Player recipient) {
+        if (!recipient.isOnline()) return false;
         if (!hasVoiceChat(recipient.getUniqueId())) return false;
 
         byte[] bytes;
@@ -418,6 +418,11 @@ public final class PlasmoVoice extends JavaPlugin implements PlasmoVoiceAPI {
                 .anyMatch(entry -> entry.getKey().getUniqueId().equals(player));
     }
 
+    @Override
+    public boolean isTalking(UUID player) {
+        return SocketServerUDP.talking.containsKey(player);
+    }
+
     @Nullable
     @Override
     public String getPlayerModLoader(UUID player) {
@@ -431,7 +436,7 @@ public final class PlasmoVoice extends JavaPlugin implements PlasmoVoiceAPI {
     }
 
     @Override
-    public List<UUID> getPlayers() {
+    public List<UUID> getConnectedPlayersUUIDs() {
         return SocketServerUDP.clients
                 .values()
                 .stream()
@@ -441,7 +446,7 @@ public final class PlasmoVoice extends JavaPlugin implements PlasmoVoiceAPI {
 
     @Override
     public void setVoiceDistances(UUID playerId, List<Integer> distances, Integer defaultDistance, Integer fadeDivisor) {
-        if (distances.size() == 0) {
+        if (distances.isEmpty()) {
             throw new IllegalArgumentException("distances should contains at least 1 element");
         }
 

--- a/src/main/java/su/plo/voice/PlasmoVoice.java
+++ b/src/main/java/su/plo/voice/PlasmoVoice.java
@@ -357,6 +357,18 @@ public final class PlasmoVoice extends JavaPlugin implements PlasmoVoiceAPI {
     }
 
     @Override
+    public @Nullable String getMuteReason(UUID player) {
+        if (!muted.containsKey(player)) throw new IllegalArgumentException("Player is not muted!");
+        return muted.get(player).getReason();
+    }
+
+    @Override
+    public long getTimestampOfMuteEnd(UUID player) {
+        if (!muted.containsKey(player)) throw new IllegalArgumentException("Player is not muted!");
+        return muted.get(player).getTo();
+    }
+
+    @Override
     public Set<Player> getConnectedPlayers() {
         return SocketServerUDP.clients.keySet();
     }

--- a/src/main/java/su/plo/voice/PlasmoVoice.java
+++ b/src/main/java/su/plo/voice/PlasmoVoice.java
@@ -163,8 +163,7 @@ public final class PlasmoVoice extends JavaPlugin implements PlasmoVoiceAPI {
             ver += Integer.parseInt(version[0]) * 1000;
             ver += Integer.parseInt(version[1]) * 100;
             ver += Integer.parseInt(version[2]);
-        } catch (NumberFormatException ignored) {
-        }
+        } catch (NumberFormatException ignored) {}
 
         return ver;
     }

--- a/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
+++ b/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
@@ -15,7 +15,7 @@ import java.util.UUID;
  * Interface for working with PlasmoVoiceAPI.<br>
  * All methods have javadocs to work with them.<br>
  *<br>
- * Contributions:<br>
+ * Contributors:<br>
  * 1) Apehum (https://github.com/Apehum) - PlasmoVoice creator.<br>
  * 2) bottleofench (https://github.com/bottleofench) - fixed and expanded the API.<br>
  */

--- a/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
+++ b/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
@@ -11,6 +11,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+/**
+ * Interface for working with PlasmoVoiceAPI.<br>
+ * All methods have javadocs to work with them.<br>
+ *<br>
+ * Contributions:<br>
+ * 1) Apehum (https://github.com/Apehum) - PlasmoVoice creator.<br>
+ * 2) bottleofench (https://github.com/bottleofench) - fixed and expanded the API.<br>
+ */
 public interface PlasmoVoiceAPI {
     /**
      * Mute the player

--- a/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
+++ b/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
@@ -33,6 +33,18 @@ public interface PlasmoVoiceAPI {
     boolean unmute(UUID player, boolean silent);
 
     /**
+     * @param player Player UUID
+     * @return null is no reason given
+     */
+    @Nullable String getMuteReason(UUID player);
+
+    /**
+     * @param player Player UUID
+     * @return returns timestamp when the mute is over
+     */
+    long getTimestampOfMuteEnd(UUID player);
+
+    /**
      * @return list of players with voice chat
      */
     Set<Player> getConnectedPlayers();

--- a/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
+++ b/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
@@ -104,6 +104,21 @@ public interface PlasmoVoiceAPI {
     List<UUID> getConnectedPlayersUUIDs();
 
     /**
+     * @return default distance at which players will hear each other
+     */
+    int getDefaultDistance();
+
+    /**
+     * @return maximum distance at which players will hear each other
+     */
+    int getMaxDistance();
+
+    /**
+     * @return maximum priority distance
+     */
+    short getMaxPriorityDistance();
+
+    /**
      * Set player voice distances
      */
     void setVoiceDistances(UUID playerId, List<Integer> distances, Integer defaultDistance, Integer fadeDivisor);

--- a/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
+++ b/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
@@ -54,6 +54,11 @@ public interface PlasmoVoiceAPI {
     boolean isMuted(UUID player);
 
     /**
+     * @return list of muted players uuids
+     */
+    List<UUID> getMutedPlayersUUIDs();
+
+    /**
      * Map of the muted players
      *
      * @return Map (key - Player UUID, value - ServerMutedEntity)

--- a/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
+++ b/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
@@ -50,7 +50,6 @@ public interface PlasmoVoiceAPI {
      * Check if the player is muted
      *
      * @param player Player UUID
-     * @return true if true, false if false 5Head
      */
     boolean isMuted(UUID player);
 

--- a/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
+++ b/src/main/java/su/plo/voice/PlasmoVoiceAPI.java
@@ -1,7 +1,7 @@
 package su.plo.voice;
 
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import su.plo.voice.common.packets.Packet;
 import su.plo.voice.data.ServerMutedEntity;
 
@@ -44,8 +44,7 @@ public interface PlasmoVoiceAPI {
      * @param recipient Recipient
      * @return true if the packet was sent successfully, false if the packet was not sent
      */
-    @ApiStatus.Experimental
-    boolean sendVoicePacketToPlayer(Packet packet, Player recipient);
+    boolean sendVoicePacketToPlayer(@NotNull Packet packet, @NotNull Player recipient);
 
     /**
      * Check if the player is muted
@@ -69,9 +68,15 @@ public interface PlasmoVoiceAPI {
     boolean hasVoiceChat(UUID player);
 
     /**
+     * @param player Online player UUID
+     * @return true if the player is talking
+     */
+    boolean isTalking(UUID player);
+
+    /**
      * Returns ModLoader of the player
      *
-     * @param player UUID игрока онлайн
+     * @param player Online Player UUID
      * @return fabric/forge or null, if the player doesn't have the mod installed
      */
     @Nullable
@@ -80,12 +85,11 @@ public interface PlasmoVoiceAPI {
     /**
      * @return List of UUIDs of the players with the mod installed
      */
-    List<UUID> getPlayers();
+    List<UUID> getConnectedPlayersUUIDs();
 
     /**
      * Set player voice distances
      */
-    @ApiStatus.Experimental
     void setVoiceDistances(UUID playerId, List<Integer> distances, Integer defaultDistance, Integer fadeDivisor);
 
     enum DurationUnit {

--- a/src/main/java/su/plo/voice/PlasmoVoiceConfig.java
+++ b/src/main/java/su/plo/voice/PlasmoVoiceConfig.java
@@ -21,12 +21,14 @@ public class PlasmoVoiceConfig {
     private final boolean disableVoiceActivation;
     private final boolean clientModRequired;
     private final int clientModCheckTimeout;
+    private final boolean disableLogs;
 
     public PlasmoVoiceConfig(String ip, int port,
                              String proxyIp, int proxyPort,
                              int sampleRate, List<Integer> distances, int defaultDistance,
                              int maxPriorityDistance, boolean disableVoiceActivation,
-                             int fadeDivisor, int priorityFadeDivisor, boolean clientModRequired, int clientModCheckTimeout) {
+                             int fadeDivisor, int priorityFadeDivisor, boolean clientModRequired,
+                             int clientModCheckTimeout, boolean disableLogs) {
         this.ip = ip;
         this.port = port;
         this.proxyIp = proxyIp;
@@ -41,5 +43,6 @@ public class PlasmoVoiceConfig {
         this.disableVoiceActivation = disableVoiceActivation;
         this.clientModRequired = clientModRequired;
         this.clientModCheckTimeout = clientModCheckTimeout;
+        this.disableLogs = disableLogs;
     }
 }

--- a/src/main/java/su/plo/voice/commands/VoiceList.java
+++ b/src/main/java/su/plo/voice/commands/VoiceList.java
@@ -5,6 +5,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import su.plo.voice.PlasmoVoice;
 import su.plo.voice.socket.SocketServerUDP;
 
@@ -14,7 +15,7 @@ import java.util.stream.Collectors;
 
 public class VoiceList implements CommandExecutor {
     @Override
-    public boolean onCommand(CommandSender sender, Command command, String s, String[] args) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String s, String[] args) {
         List<String> clients = SocketServerUDP.clients.keySet().stream()
                 .map(Player::getName)
                 .collect(Collectors.toList());

--- a/src/main/java/su/plo/voice/commands/VoiceMute.java
+++ b/src/main/java/su/plo/voice/commands/VoiceMute.java
@@ -12,6 +12,7 @@ import su.plo.voice.PlasmoVoiceAPI;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -42,44 +43,42 @@ public class VoiceMute implements TabExecutor {
         PlasmoVoiceAPI.DurationUnit durationUnit = null;
         long duration = 0;
         String reason = null;
-        if (args.length > 1) {
-            if (!args[1].startsWith("perm")) {
-                Matcher matcher = pattern.matcher(args[1]);
-                if (matcher.find()) {
-                    duration = Integer.parseInt(matcher.group(1));
-                    if (duration > 0) {
-                        String type = matcher.group(2);
-                        if (type == null) {
-                            type = "";
-                        }
+        if (args.length > 1 && !args[1].startsWith("perm")) {
+            Matcher matcher = pattern.matcher(args[1]);
+            if (matcher.find()) {
+                duration = Integer.parseInt(matcher.group(1));
+                if (duration > 0) {
+                    String type = matcher.group(2);
+                    if (type == null) {
+                        type = "";
+                    }
 
-                        switch (type) {
-                            case "m":
-                                durationUnit = PlasmoVoiceAPI.DurationUnit.MINUTES;
-                                break;
-                            case "h":
-                                durationUnit = PlasmoVoiceAPI.DurationUnit.HOURS;
-                                break;
-                            case "d":
-                                durationUnit = PlasmoVoiceAPI.DurationUnit.DAYS;
-                                break;
-                            case "w":
-                                durationUnit = PlasmoVoiceAPI.DurationUnit.WEEKS;
-                                break;
-                            case "u":
-                                duration = duration - System.currentTimeMillis() / 1000L;
-                                durationUnit = PlasmoVoiceAPI.DurationUnit.TIMESTAMP;
-                                break;
-                            default:
-                                durationUnit = PlasmoVoiceAPI.DurationUnit.SECONDS;
-                                break;
-                        }
-                    } else {
-                        durationUnit = PlasmoVoiceAPI.DurationUnit.SECONDS;
+                    switch (type) {
+                        case "m":
+                            durationUnit = PlasmoVoiceAPI.DurationUnit.MINUTES;
+                            break;
+                        case "h":
+                            durationUnit = PlasmoVoiceAPI.DurationUnit.HOURS;
+                            break;
+                        case "d":
+                            durationUnit = PlasmoVoiceAPI.DurationUnit.DAYS;
+                            break;
+                        case "w":
+                            durationUnit = PlasmoVoiceAPI.DurationUnit.WEEKS;
+                            break;
+                        case "u":
+                            duration = duration - System.currentTimeMillis() / 1000L;
+                            durationUnit = PlasmoVoiceAPI.DurationUnit.TIMESTAMP;
+                            break;
+                        default:
+                            durationUnit = PlasmoVoiceAPI.DurationUnit.SECONDS;
+                            break;
                     }
                 } else {
-                    reason = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
+                    durationUnit = PlasmoVoiceAPI.DurationUnit.SECONDS;
                 }
+            } else {
+                reason = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
             }
         }
 
@@ -123,6 +122,6 @@ public class VoiceMute implements TabExecutor {
                 return durations;
             }
         }
-        return null;
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/su/plo/voice/commands/VoiceMute.java
+++ b/src/main/java/su/plo/voice/commands/VoiceMute.java
@@ -6,6 +6,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import su.plo.voice.PlasmoVoice;
 import su.plo.voice.PlasmoVoiceAPI;
 
@@ -16,11 +17,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class VoiceMute implements TabExecutor {
-    private final Pattern pattern = Pattern.compile("^([0-9]*)([mhdwu])?$");
-    private final Pattern integerPattern = Pattern.compile("^([0-9]*)$");
+    private final Pattern pattern = Pattern.compile("^(\\d*)([mhdwu])?$");
+    private final Pattern integerPattern = Pattern.compile("^(\\d*)$");
 
     @Override
-    public boolean onCommand(CommandSender sender, Command command, String s, String[] args) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String s, String[] args) {
         if (args.length == 0) {
             sender.sendMessage(PlasmoVoice.getInstance().getMessagePrefix("help.mute"));
             return true;
@@ -106,7 +107,7 @@ public class VoiceMute implements TabExecutor {
     }
 
     @Override
-    public List<String> onTabComplete(CommandSender sender, Command command, String s, String[] args) {
+    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String s, String[] args) {
         if (args.length == 2) {
             if (args[1].isEmpty()) {
                 return ImmutableList.of("permanent");

--- a/src/main/java/su/plo/voice/commands/VoiceMuteList.java
+++ b/src/main/java/su/plo/voice/commands/VoiceMuteList.java
@@ -14,7 +14,7 @@ import java.util.Date;
 public class VoiceMuteList implements CommandExecutor {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (PlasmoVoice.getInstance().getMutedMap().size() == 0) {
+        if (PlasmoVoice.getInstance().getMutedMap().isEmpty()) {
             sender.sendMessage(PlasmoVoice.getInstance().getMessagePrefix("muted_list_empty"));
             return true;
         }

--- a/src/main/java/su/plo/voice/commands/VoiceReconnect.java
+++ b/src/main/java/su/plo/voice/commands/VoiceReconnect.java
@@ -4,12 +4,13 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import su.plo.voice.PlasmoVoice;
 import su.plo.voice.listeners.PlayerListener;
 
 public class VoiceReconnect implements CommandExecutor {
     @Override
-    public boolean onCommand(CommandSender sender, Command command, String s, String[] args) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String s, String[] args) {
         if (!(sender instanceof Player)) {
             return true;
         }

--- a/src/main/java/su/plo/voice/commands/VoiceReload.java
+++ b/src/main/java/su/plo/voice/commands/VoiceReload.java
@@ -5,6 +5,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import su.plo.voice.PlasmoVoice;
 import su.plo.voice.PlasmoVoiceConfig;
 import su.plo.voice.common.packets.tcp.ConfigPacket;
@@ -18,7 +19,7 @@ import java.util.Enumeration;
 
 public class VoiceReload implements CommandExecutor {
     @Override
-    public boolean onCommand(CommandSender sender, Command command, String s, String[] args) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String s, String[] args) {
         PlasmoVoice.getInstance().reloadConfig();
         PlasmoVoice.getInstance().updateConfig();
 

--- a/src/main/java/su/plo/voice/commands/VoiceUnmute.java
+++ b/src/main/java/su/plo/voice/commands/VoiceUnmute.java
@@ -20,7 +20,7 @@ public class VoiceUnmute implements TabExecutor {
         }
 
         OfflinePlayer player = Bukkit.getOfflinePlayer(args[0]);
-        if (player.hasPlayedBefore() || player.getName() == null) {
+        if (!player.hasPlayedBefore() || player.getName() == null) {
             sender.sendMessage(PlasmoVoice.getInstance().getMessagePrefix("player_not_found"));
             return true;
         }

--- a/src/main/java/su/plo/voice/commands/VoiceUnmute.java
+++ b/src/main/java/su/plo/voice/commands/VoiceUnmute.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public class VoiceUnmute implements TabExecutor {
     @Override
-    public boolean onCommand(CommandSender sender, Command command, String s, String[] args) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String s, String[] args) {
         if (args.length == 0) {
             sender.sendMessage(PlasmoVoice.getInstance().getMessagePrefix("help.unmute"));
             return true;

--- a/src/main/java/su/plo/voice/commands/VoiceUnmute.java
+++ b/src/main/java/su/plo/voice/commands/VoiceUnmute.java
@@ -20,7 +20,7 @@ public class VoiceUnmute implements TabExecutor {
         }
 
         OfflinePlayer player = Bukkit.getOfflinePlayer(args[0]);
-        if (player.getFirstPlayed() == 0 || player.getName() == null) {
+        if (player.hasPlayedBefore() || player.getName() == null) {
             sender.sendMessage(PlasmoVoice.getInstance().getMessagePrefix("player_not_found"));
             return true;
         }

--- a/src/main/java/su/plo/voice/events/PlayerConfigEvent.java
+++ b/src/main/java/su/plo/voice/events/PlayerConfigEvent.java
@@ -8,6 +8,9 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 import su.plo.voice.common.packets.tcp.ConfigPacket;
 
+/**
+ * Fires when the player's config has been changed / read etc.
+ */
 public class PlayerConfigEvent extends Event implements Cancellable {
     private static final HandlerList HANDLERS_LIST = new HandlerList();
     @Getter
@@ -38,15 +41,20 @@ public class PlayerConfigEvent extends Event implements Cancellable {
     @Override
     public void setCancelled(boolean cancel) {
         if (cancel && cause.equals(Cause.CONNECT)) {
-            throw new IllegalStateException("Cannot cancelPlayerConfigEvent event with cause CONNECT");
+            throw new IllegalStateException("Cannot cancel PlayerConfigEvent event if cause is CONNECT!");
         }
 
         this.cancelled = cancel;
     }
 
+    /**
+     * CONNECT is when player is connecting to voice chat.<p>
+     * RELOAD is when plugin config is reloading.<p>
+     * PLUGIN is when event fires, called by third-party plugins which using PlasmoVoice API.
+     */
     public enum Cause {
         CONNECT,
         RELOAD,
-        PLUGIN // called from API
+        PLUGIN
     }
 }

--- a/src/main/java/su/plo/voice/events/PlayerEndSpeakEvent.java
+++ b/src/main/java/su/plo/voice/events/PlayerEndSpeakEvent.java
@@ -1,20 +1,21 @@
 package su.plo.voice.events;
 
+import lombok.Getter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Fires when the player's talk is ended
+ */
 public class PlayerEndSpeakEvent extends Event {
     private static final HandlerList HANDLERS_LIST = new HandlerList();
+    @Getter
     private final Player player;
 
     public PlayerEndSpeakEvent(Player player) {
         super(true);
         this.player = player;
-    }
-
-    public Player getPlayer() {
-        return this.player;
     }
 
     @Override

--- a/src/main/java/su/plo/voice/events/PlayerSpeakEvent.java
+++ b/src/main/java/su/plo/voice/events/PlayerSpeakEvent.java
@@ -5,7 +5,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-import su.plo.voice.common.packets.Packet;
+import su.plo.voice.common.packets.udp.VoiceServerPacket;
 
 /**
  * Fires when player is speaking in voice chat
@@ -16,9 +16,9 @@ public class PlayerSpeakEvent extends Event implements Cancellable {
     @Getter
     private final Player player;
     @Getter
-    private final Packet packet;
+    private final VoiceServerPacket packet;
 
-    public PlayerSpeakEvent(Player player, Packet packet) {
+    public PlayerSpeakEvent(Player player, VoiceServerPacket packet) {
         super(true);
         this.player = player;
         this.packet = packet;

--- a/src/main/java/su/plo/voice/events/PlayerSpeakEvent.java
+++ b/src/main/java/su/plo/voice/events/PlayerSpeakEvent.java
@@ -1,15 +1,21 @@
 package su.plo.voice.events;
 
+import lombok.Getter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import su.plo.voice.common.packets.Packet;
 
+/**
+ * Fires when player is speaking in voice chat
+ */
 public class PlayerSpeakEvent extends Event implements Cancellable {
     private static final HandlerList HANDLERS_LIST = new HandlerList();
     private boolean cancelled = false;
+    @Getter
     private final Player player;
+    @Getter
     private final Packet packet;
 
     public PlayerSpeakEvent(Player player, Packet packet) {
@@ -18,27 +24,19 @@ public class PlayerSpeakEvent extends Event implements Cancellable {
         this.packet = packet;
     }
 
-    public Player getPlayer() {
-        return this.player;
-    }
-
     @Override
     public boolean isCancelled() {
-        return this.cancelled;
+        return cancelled;
     }
 
     @Override
     public void setCancelled(boolean cancel) {
-        this.cancelled = cancel;
+        cancelled = cancel;
     }
 
     @Override
     public HandlerList getHandlers() {
         return HANDLERS_LIST;
-    }
-
-    public Packet getPacket() {
-        return packet;
     }
 
     public static HandlerList getHandlerList() {

--- a/src/main/java/su/plo/voice/events/PlayerStartSpeakEvent.java
+++ b/src/main/java/su/plo/voice/events/PlayerStartSpeakEvent.java
@@ -1,20 +1,21 @@
 package su.plo.voice.events;
 
+import lombok.Getter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Fires when the player's talk is started
+ */
 public class PlayerStartSpeakEvent extends Event {
     private static final HandlerList HANDLERS_LIST = new HandlerList();
+    @Getter
     private final Player player;
 
     public PlayerStartSpeakEvent(Player player) {
         super(true);
         this.player = player;
-    }
-
-    public Player getPlayer() {
-        return this.player;
     }
 
     @Override

--- a/src/main/java/su/plo/voice/events/PlayerVoiceConnectedEvent.java
+++ b/src/main/java/su/plo/voice/events/PlayerVoiceConnectedEvent.java
@@ -7,6 +7,9 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Fires when player connects to voice chat
+ */
 @AllArgsConstructor
 public class PlayerVoiceConnectedEvent extends Event {
     private static final HandlerList HANDLERS_LIST = new HandlerList();

--- a/src/main/java/su/plo/voice/events/PlayerVoiceDisconnectedEvent.java
+++ b/src/main/java/su/plo/voice/events/PlayerVoiceDisconnectedEvent.java
@@ -7,6 +7,9 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Fires when player disconnects from voice chat
+ */
 @AllArgsConstructor
 public class PlayerVoiceDisconnectedEvent extends Event {
     private static final HandlerList HANDLERS_LIST = new HandlerList();

--- a/src/main/java/su/plo/voice/events/PlayerVoiceMuteEvent.java
+++ b/src/main/java/su/plo/voice/events/PlayerVoiceMuteEvent.java
@@ -20,7 +20,7 @@ public class PlayerVoiceMuteEvent extends Event {
     }
 
     /**
-     * @return 0L if mute is permanent, else return usual timestamp in milliseconds
+     * @return <= 0 if mute is permanent, else return usual timestamp in milliseconds
      */
     public Long getMuteDuration() {
         return muteDuration;

--- a/src/main/java/su/plo/voice/events/PlayerVoiceMuteEvent.java
+++ b/src/main/java/su/plo/voice/events/PlayerVoiceMuteEvent.java
@@ -1,25 +1,29 @@
 package su.plo.voice.events;
 
+import lombok.Getter;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Fires when the player has been muted
+ */
 public class PlayerVoiceMuteEvent extends Event {
     private static final HandlerList HANDLERS_LIST = new HandlerList();
+    @Getter
     private final OfflinePlayer player;
-    private final Long to;
+    private final Long muteDuration;
 
     public PlayerVoiceMuteEvent(OfflinePlayer player, long duration) {
         this.player = player;
-        this.to = duration;
+        this.muteDuration = duration;
     }
 
-    public Long getTo() {
-        return to;
-    }
-
-    public OfflinePlayer getPlayer() {
-        return this.player;
+    /**
+     * @return 0L if mute is permanent, else return usual timestamp in milliseconds
+     */
+    public Long getMuteDuration() {
+        return muteDuration;
     }
 
     @Override

--- a/src/main/java/su/plo/voice/events/PlayerVoiceUnmuteEvent.java
+++ b/src/main/java/su/plo/voice/events/PlayerVoiceUnmuteEvent.java
@@ -1,5 +1,6 @@
 package su.plo.voice.events;
 
+import lombok.Getter;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -9,14 +10,11 @@ import org.bukkit.event.HandlerList;
  */
 public class PlayerVoiceUnmuteEvent extends Event {
     private static final HandlerList HANDLERS_LIST = new HandlerList();
+    @Getter
     private final OfflinePlayer player;
 
     public PlayerVoiceUnmuteEvent(OfflinePlayer player) {
         this.player = player;
-    }
-
-    public OfflinePlayer getPlayer() {
-        return this.player;
     }
 
     @Override

--- a/src/main/java/su/plo/voice/events/PlayerVoiceUnmuteEvent.java
+++ b/src/main/java/su/plo/voice/events/PlayerVoiceUnmuteEvent.java
@@ -1,10 +1,12 @@
 package su.plo.voice.events;
 
 import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Fires when the player has been unmuted
+ */
 public class PlayerVoiceUnmuteEvent extends Event {
     private static final HandlerList HANDLERS_LIST = new HandlerList();
     private final OfflinePlayer player;

--- a/src/main/java/su/plo/voice/listeners/PlayerListener.java
+++ b/src/main/java/su/plo/voice/listeners/PlayerListener.java
@@ -86,7 +86,7 @@ public class PlayerListener implements Listener {
         if (PlasmoVoice.getInstance().getVoiceConfig().isClientModRequired()) {
             kickTimeouts.put(player.getUniqueId(), Bukkit.getScheduler().runTaskLater(PlasmoVoice.getInstance(), () -> {
                 if (!SocketServerUDP.clients.containsKey(player)) {
-                    if (!PlasmoVoice.getInstance().getConfig().getBoolean("disable_logs")) {
+                    if (!PlasmoVoice.getInstance().getVoiceConfig().isDisableLogs()) {
                         PlasmoVoice.getVoiceLogger().info(String.format("Player: %s does not have the mod installed!", player.getName()));
                     }
                     player.kickPlayer(PlasmoVoice.getInstance().getMessage("mod_missing_kick_message"));

--- a/src/main/java/su/plo/voice/placeholders/PlaceholderPlasmoVoice.java
+++ b/src/main/java/su/plo/voice/placeholders/PlaceholderPlasmoVoice.java
@@ -6,19 +6,23 @@ import org.jetbrains.annotations.NotNull;
 import su.plo.voice.socket.SocketServerUDP;
 
 public class PlaceholderPlasmoVoice extends PlaceholderExpansion {
+    private static final String identifier = "plasmovoice";
+    private static final String author = "Apehum";
+    private static final String version = "1.0.0";
+
     @Override
     public @NotNull String getIdentifier() {
-        return "plasmovoice";
+        return identifier;
     }
 
     @Override
     public @NotNull String getAuthor() {
-        return "Apehum";
+        return author;
     }
 
     @Override
     public @NotNull String getVersion() {
-        return "1.0.0";
+        return version;
     }
 
     @Override

--- a/src/main/java/su/plo/voice/socket/SocketClientUDP.java
+++ b/src/main/java/su/plo/voice/socket/SocketClientUDP.java
@@ -34,7 +34,7 @@ public class SocketClientUDP {
             Bukkit.getScheduler().runTask(PlasmoVoice.getInstance(), () ->
                     Bukkit.getPluginManager().callEvent(new PlayerVoiceDisconnectedEvent(player)));
 
-            if (!PlasmoVoice.getInstance().getConfig().getBoolean("disable_logs")) {
+            if (!PlasmoVoice.getInstance().getVoiceConfig().isDisableLogs()) {
                 PlasmoVoice.getVoiceLogger().info("Remove client UDP: " + this.player.getName());
             }
             SocketServerUDP.clients.remove(player);

--- a/src/main/java/su/plo/voice/socket/SocketServerUDP.java
+++ b/src/main/java/su/plo/voice/socket/SocketServerUDP.java
@@ -81,6 +81,7 @@ public class SocketServerUDP extends Thread {
         }
     }
 
+    @Override
     public void run() {
         try {
             socket = new DatagramSocket(this.addr);

--- a/src/main/java/su/plo/voice/socket/SocketServerUDPQueue.java
+++ b/src/main/java/su/plo/voice/socket/SocketServerUDPQueue.java
@@ -197,7 +197,7 @@ public class SocketServerUDPQueue extends Thread {
             } catch (IOException e) {
                 e.printStackTrace();
             } catch (InterruptedException ignored) {
-                break; // TODO maybe use this.interrupt before break?
+                break;
             }
         }
     }

--- a/src/main/java/su/plo/voice/socket/SocketServerUDPQueue.java
+++ b/src/main/java/su/plo/voice/socket/SocketServerUDPQueue.java
@@ -103,7 +103,7 @@ public class SocketServerUDPQueue extends Thread {
                                     new ClientConnectedPacket(player.get().getUniqueId(), playerMuted), player.get().getUniqueId(), player.get()
                             );
 
-                            if (!PlasmoVoice.getInstance().getConfig().getBoolean("disable_logs")) {
+                            if (!PlasmoVoice.getInstance().getVoiceConfig().isDisableLogs()) {
                                 PlasmoVoice.getVoiceLogger().info(String.format("New client: %s", player.get().getName()));
                             }
 
@@ -225,7 +225,7 @@ public class SocketServerUDPQueue extends Thread {
             }
         }
         for (Player player : connectionsToDrop) {
-            if (!PlasmoVoice.getInstance().getConfig().getBoolean("disable_logs")) {
+            if (!PlasmoVoice.getInstance().getVoiceConfig().isDisableLogs()) {
                 PlasmoVoice.getVoiceLogger().info(player.getName() + " UDP timed out");
                 PlasmoVoice.getVoiceLogger().info(player.getName() + " sent reconnect packet");
             }

--- a/src/main/java/su/plo/voice/socket/SocketServerUDPQueue.java
+++ b/src/main/java/su/plo/voice/socket/SocketServerUDPQueue.java
@@ -197,7 +197,7 @@ public class SocketServerUDPQueue extends Thread {
             } catch (IOException e) {
                 e.printStackTrace();
             } catch (InterruptedException ignored) {
-                break;
+                break; // TODO maybe use this.interrupt before break?
             }
         }
     }
@@ -207,11 +207,10 @@ public class SocketServerUDPQueue extends Thread {
         PingPacket keepAlive = new PingPacket();
         List<Player> connectionsToDrop = new ArrayList<>(SocketServerUDP.clients.size());
         for (SocketClientUDP connection : SocketServerUDP.clients.values()) {
-            if (SocketServerUDP.talking.containsKey(connection.getPlayer().getUniqueId())) {
-                if (timestamp - SocketServerUDP.talking.get(connection.getPlayer().getUniqueId()) > 250L) {
-                    SocketServerUDP.talking.remove(connection.getPlayer().getUniqueId());
-                    Bukkit.getPluginManager().callEvent(new PlayerEndSpeakEvent(connection.getPlayer()));
-                }
+            if (SocketServerUDP.talking.containsKey(connection.getPlayer().getUniqueId()) &&
+                    timestamp - SocketServerUDP.talking.get(connection.getPlayer().getUniqueId()) > 250L) {
+                SocketServerUDP.talking.remove(connection.getPlayer().getUniqueId());
+                Bukkit.getPluginManager().callEvent(new PlayerEndSpeakEvent(connection.getPlayer()));
             }
 
             if (timestamp - connection.getKeepAlive() >= 15000L) {

--- a/src/main/java/su/plo/voice/socket/SocketServerUDPQueue.java
+++ b/src/main/java/su/plo/voice/socket/SocketServerUDPQueue.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class SocketServerUDPQueue extends Thread {
     public LinkedBlockingQueue<PacketUDP> queue = new LinkedBlockingQueue<>();
 
+    @Override
     public void run() {
         while (!this.isInterrupted()) {
             try {

--- a/src/main/java/su/plo/voice/socket/SocketServerUDPQueue.java
+++ b/src/main/java/su/plo/voice/socket/SocketServerUDPQueue.java
@@ -112,11 +112,7 @@ public class SocketServerUDPQueue extends Thread {
                                     Bukkit.getPluginManager().callEvent(new PlayerVoiceConnectedEvent(player.get())));
                         }
 
-                        try {
-                            SocketServerUDP.sendTo(PacketUDP.write(new AuthPacketAck()), sock);
-                        } catch (IOException e) {
-                            e.printStackTrace();
-                        }
+                        SocketServerUDP.sendTo(PacketUDP.write(new AuthPacketAck()), sock);
                     }
                 }
 


### PR DESCRIPTION
Still in development!
If you want to test this updates, here is the [updated jar](https://cdn.discordapp.com/attachments/760175424620986388/1004628343645282335/plasmovoice-server-1.0.12.jar)
(The link will be updated after almost every commit)

**Referring to third-party developers:**
Write what else you would like to see in the API.

API changes:
- New API methods: 
1) `isTalking()` ; 
2) `getMutedPlayersUUIDs()` ; 
3) `getMuteReason()` ; 
4) `getTimestampOfMuteEnd()` ;
5) `getMaxDistance()` ;
6) `getDefaultDistance()` ;
7) `getMaxPriorityDistance`
- Added Javadocs for all events;
- Updated PlayerVoiceMuteEvent and PlayerConfigEvent;
- Added `@NotNull` annotations to `sendVoicePacketToPlayer()` method;
- Removed `@ApiStatus.Experimental` annotations for API methods;
- Remove unneccesary import in PlayerVoiceUnmuteEvent;
- Used `@Getter` in all event classes;
- Updated API examples in README.md;
- Renamed `getPlayers()` method to `getConnectedPlayersUUIDs()` ;
- Fixed javadoc for `getPlayerModLoader()` method;
- Added `!recipient.isOnline` check to `sendVoicePacketToPlayer()` method;
- Replaced Packet to VoiceServerPacket in PlayerSpeakEvent

Other changes:
- Added missing `@NotNull` annotations in commands classes;
- Replaced statement lambda to expression lambda in PlayerListener;
- Modified regex for VoiceMute class (`[0-9] -> \\d`);
- Replaced `size() == 0` checks to `isEmpty()` ;
- Merged two if-statements in one in main class;
- Replaced deprecated `{version}` to `{project.version}` in pom.xml;
- Used Collections.emptyList() instead of null;
- Merged some if-statements;
- Optimized PlaceholderPlasmoVoice class;
- Replaced `player.getFirstPlayed() == 0` check to `!player.hasPlayedBefore()` in VoiceUnmute class;
- Added `disableLogs` to PlasmoVoiceConfig class;
- Remove nested try-catch block in SocketServerUDPQueue;
- Added `@Override` annotations in SocketServerUDP and SocketServerUDPQueue
