### PR TITLE
fix(client): fix distorted RNNoise output during mono capture

### DIFF
--- a/api/common/src/main/java/su/plo/voice/api/util/AudioUtil.java
+++ b/api/common/src/main/java/su/plo/voice/api/util/AudioUtil.java
@@ -60,7 +60,15 @@ public final class AudioUtil {
         short[] shorts = new short[floats.length];
 
         for(int i = 0; i < floats.length; i++) {
-            shorts[i] = Float.valueOf(floats[i]).shortValue();
+            shorts[i] = Float.valueOf(
+                    Math.min( // Clamp to prevent overdrive causing clipping (https://github.com/remjey/mumble/commit/f16b47c81aceaf0c8704b355d9316bf685cb3704)
+                            Short.MAX_VALUE,
+                            Math.max(
+                                    Short.MIN_VALUE,
+                                    floats[i]
+                            )
+                    )
+            ).shortValue();
         }
 
         return shorts;


### PR DESCRIPTION
Fix sourced from https://github.com/remjey/mumble/commit/f16b47c81aceaf0c8704b355d9316bf685cb3704

> When the input signal is very loud and clipping, the output of RNNoise is very distorted, way more than the input signal.
> 
> This is because RNNoise outputs a signal that is unbounded and sometimes goes over the limits of the signed 16-bit signal that Mumble uses internally. When Mumble converts RNNoise output signal to 16-bit, integer overflow occurs and creates a very loud distortion.
> 
> Mumble now clamps the output of RNNoise which results in a signal that is not more distorted than the input signal.

This code clamps the values sent to RNNoise to prevent loud overdrive clipping, fixing #370 