### PR TITLE
Metrics

### DIFF
--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -1,0 +1,62 @@
+name: Publish PR
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: |
+          8
+          16
+          17
+          21
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v5
+      with:
+        cache-read-only: false
+
+    - name: Build with Gradle
+      run: ./gradlew build --stacktrace -Psnapshot=true
+
+    - name: Get Head Commit Message
+      id: commit
+      run: echo "HEAD_COMMIT_MESSAGE=$(git show -s --format=%s)" >> "$GITHUB_OUTPUT"
+
+    - name: Upload to Registry
+      run: |
+        if [ -z "${{ secrets.REGISTRY_URL }}" ] || [ -z "${{ secrets.REGISTRY_UPLOAD_TOKEN }}" ]; then
+          echo "Registry secrets not configured, skipping upload"
+          exit 0
+        fi
+      
+        for file in build/libs/*; do
+          echo "Uploading $(basename $file)..."
+        
+          if curl -X POST "${{ secrets.REGISTRY_URL }}/upload" \
+            -H "Authorization: Bearer ${{ secrets.REGISTRY_UPLOAD_TOKEN }}" \
+            -F "repoUrl=${{ github.server_url }}/${{ github.repository }}" \
+            -F "project=${{ github.event.repository.name  }}" \
+            -F "branch=${{ github.head_ref }}" \
+            -F "commit=${{ github.sha }}" \
+            -F "message=${{ steps.commit.outputs.HEAD_COMMIT_MESSAGE }}" \
+            -F "file=@$file" \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-all-errors \
+            --fail-with-body \
+            --show-error; then
+            echo "✓ Uploaded $(basename $file)"
+          else
+            echo "✗ Failed to upload $(basename $file) after retries"
+            exit 1
+          fi
+        done

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -8,9 +8,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
+
+    - name: Free disk space
+      uses: BRAINSia/free-disk-space@v2
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: true
+        swap-storage: false
+
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: |

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ classes/
 *.launch
 *_key.txt
 previousDocVersions/
+.kotlin/

--- a/api/server/src/main/java/su/plo/voice/api/server/config/ServerConfig.java
+++ b/api/server/src/main/java/su/plo/voice/api/server/config/ServerConfig.java
@@ -26,6 +26,8 @@ public interface ServerConfig {
 
     @NotNull Voice voice();
 
+    @NotNull Metrics metrics();
+
     interface Host {
 
         @NotNull String ip();
@@ -102,5 +104,15 @@ public interface ServerConfig {
 
             int bitrate();
         }
+    }
+
+    interface Metrics {
+        boolean enabled();
+
+        boolean jvmMetrics();
+
+        @NotNull String ip();
+
+        int port();
     }
 }

--- a/api/server/src/main/java/su/plo/voice/api/server/event/connection/UdpPacketSentEvent.java
+++ b/api/server/src/main/java/su/plo/voice/api/server/event/connection/UdpPacketSentEvent.java
@@ -16,4 +16,5 @@ public final class UdpPacketSentEvent implements Event {
 
     private final @NonNull UdpServerConnection connection;
     private final @NonNull Packet<?> packet;
+    private final int packetEncodedSize;
 }

--- a/api/server/src/main/java/su/plo/voice/api/server/socket/UdpServerConnection.java
+++ b/api/server/src/main/java/su/plo/voice/api/server/socket/UdpServerConnection.java
@@ -16,25 +16,39 @@ public interface UdpServerConnection extends UdpConnection {
     @NotNull VoiceServerPlayer getPlayer();
 
     /**
-     * Gets the timestamp of the last received keep-alive signal from this connection.
+     * Gets the timestamp of the last received keep-alive packet from this connection.
      *
-     * @return The timestamp of the last received keep-alive signal.
+     * @return The timestamp of the last received keep-alive packet.
      */
     long getKeepAlive();
 
     /**
-     * Gets the timestamp of the last sent keep-alive signal to this connection.
+     * Gets the timestamp of the last sent keep-alive packet to this connection.
      *
-     * @return The timestamp of the last sent keep-alive signal.
+     * @return The timestamp of the last sent keep-alive packet.
      */
     long getSentKeepAlive();
 
     /**
-     * Sets the timestamp of the last sent keep-alive signal to this connection.
+     * Sets the timestamp of the last sent keep-alive packet to this connection.
      *
-     * @param keepAlive The timestamp of the last sent keep-alive signal.
+     * @param keepAlive The timestamp of the last sent keep-alive packet.
      */
     void setSentKeepAlive(long keepAlive);
+
+    /**
+     * Gets the timestamp of the next scheduled keep alive packet.
+     *
+     * @return The timestamp of the next scheduled keep-alive packet.
+     */
+    long getNextKeepAlive();
+
+    /**
+     * Sets the timestamp of the next scheduled keep alive packet.
+     *
+     * @param keepAlive The timestamp of the next scheduled keep alive packet.
+     */
+    void setNextKeepAlive(long keepAlive);
 
     /**
      * Gets the timestamp of the last received packet from this connection.

--- a/buildSrc/src/main/kotlin/su/plo/voice/shadow.gradle.kts
+++ b/buildSrc/src/main/kotlin/su/plo/voice/shadow.gradle.kts
@@ -56,8 +56,12 @@ tasks {
             relocate(packageName, "su.plo.voice.libs.$outputPackage")
         }
 
-        relocate("su.plo.crowdin", "su.plo.voice.libs.crowdin")
-        relocate("org.bstats", "su.plo.voice.libs.bstats")
+        reloc("io.micrometer")
+        reloc("io.prometheus")
+        reloc("org.HdrHistogram")
+        reloc("org.LatencyUtils")
+        reloc("org.eclipse")
+        reloc("org.http4k")
 
         reloc("kotlin")
         reloc("kotlinx.coroutines")

--- a/client/src/main/kotlin/su/plo/voice/client/render/cape/DeveloperCapeManager.kt
+++ b/client/src/main/kotlin/su/plo/voice/client/render/cape/DeveloperCapeManager.kt
@@ -5,6 +5,7 @@ import com.google.common.cache.Cache
 import com.google.common.cache.CacheBuilder
 import com.google.common.hash.Hashing
 import com.mojang.authlib.minecraft.MinecraftProfileTexture
+import com.mojang.blaze3d.systems.RenderSystem
 import net.minecraft.client.Minecraft
 import net.minecraft.resources.ResourceLocation
 import su.plo.lib.mod.client.ResourceLocationUtil
@@ -133,10 +134,12 @@ object DeveloperCapeManager {
             //$$ } catch (ignored: Exception) {
             //$$ }
             //#else
-            Minecraft.getInstance().textureManager.register(
-                capeLocation,
-                HttpTexture(capeFile, texture.url, ModPlayerSkins.getDefaultSkin(UUID.randomUUID()), false) {}
-            )
+            RenderSystem.recordRenderCall {
+                Minecraft.getInstance().textureManager.register(
+                    capeLocation,
+                    HttpTexture(capeFile, texture.url, ModPlayerSkins.getDefaultSkin(UUID.randomUUID()), false) {}
+                )
+            }
             //#endif
 
             capeLocation

--- a/common/src/main/kotlin/su/plo/voice/socket/NettyExceptionHandler.kt
+++ b/common/src/main/kotlin/su/plo/voice/socket/NettyExceptionHandler.kt
@@ -4,8 +4,10 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import su.plo.voice.BaseVoice
 
-class NettyExceptionHandler : ChannelInboundHandlerAdapter() {
+class NettyExceptionHandler(
+    private val message: String = "Failed to handle packet",
+) : ChannelInboundHandlerAdapter() {
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
-        BaseVoice.DEBUG_LOGGER.log("Failed to decode packet", cause)
+        BaseVoice.DEBUG_LOGGER.log(message, cause)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,8 @@ bstats = "3.0.2"
 luckperms = "5.4"
 papi = "2.11.6"
 supervanish = "6.2.18-3"
+micrometer = "1.15.5"
+http4k = "6.15.1.0"
 
 bungeecord = "1.21-R0.5-SNAPSHOT"
 velocity = "3.1.1"
@@ -53,6 +55,11 @@ config       = { module = "su.plo.config:config", version.ref = "config" }
 luckperms    = { module = "net.luckperms:api", version.ref = "luckperms" }
 papi         = { module = "me.clip:placeholderapi", version.ref = "papi" }
 supervanish  = { module = "com.github.LeonMangler:SuperVanish", version.ref = "supervanish" }
+
+micrometer-core       = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }
+micrometer-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
+http4k-core           = { module = "org.http4k:http4k-core", version.ref = "http4k" }
+http4k-jetty          = { module = "org.http4k:http4k-server-jetty", version.ref = "http4k" }
 
 bungeecord   = { module = "net.md-5:bungeecord-api", version.ref = "bungeecord"}
 velocity     = { module = "com.velocitypowered:velocity-api", version.ref = "velocity" }

--- a/proxy/common/src/main/java/su/plo/voice/proxy/BaseVoiceProxy.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/BaseVoiceProxy.java
@@ -170,7 +170,7 @@ public abstract class BaseVoiceProxy extends BaseVoice implements PlasmoVoicePro
             if (System.getenv("PLASMO_VOICE_FORWARDING_SECRET") != null) {
                 forwardingSecret = UUID.fromString(System.getenv("PLASMO_VOICE_FORWARDING_SECRET"));
             } else if (forwardingSecretFile.exists()) {
-                forwardingSecret = UUID.fromString(new String(Files.readAllBytes(forwardingSecretFile.toPath())));
+                forwardingSecret = UUID.fromString(new String(Files.readAllBytes(forwardingSecretFile.toPath())).trim());
             } else {
                 forwardingSecret = UUID.randomUUID();
                 Files.write(forwardingSecretFile.toPath(), forwardingSecret.toString().getBytes(StandardCharsets.UTF_8));
@@ -189,7 +189,7 @@ public abstract class BaseVoiceProxy extends BaseVoice implements PlasmoVoicePro
                 if (System.getenv("PLASMO_VOICE_AES_KEY") != null) {
                     aesEncryptionKey = UUID.fromString(System.getenv("PLASMO_VOICE_AES_KEY"));
                 } else if (aesEncryptionKeyFile.exists()) {
-                    aesEncryptionKey = UUID.fromString(new String(Files.readAllBytes(aesEncryptionKeyFile.toPath())));
+                    aesEncryptionKey = UUID.fromString(new String(Files.readAllBytes(aesEncryptionKeyFile.toPath())).trim());
                 } else {
                     aesEncryptionKey = UUID.randomUUID();
                 }

--- a/server/common/build.gradle.kts
+++ b/server/common/build.gradle.kts
@@ -14,14 +14,16 @@ dependencies {
 
     compileOnly(libs.netty)
 
-    implementation(libs.micrometer.core)
-    implementation(libs.micrometer.prometheus)
-
-    implementation(libs.http4k.core) {
-        excludeKotlin()
-    }
-    implementation(libs.http4k.jetty) {
-        excludeKotlin()
+    listOf(
+        libs.micrometer.core,
+        libs.micrometer.prometheus,
+        libs.http4k.core,
+        libs.http4k.jetty
+    ).forEach {
+        implementation(it) {
+            excludeKotlin()
+        }
+        testImplementation(it)
     }
 
     testImplementation(libs.mockito)

--- a/server/common/build.gradle.kts
+++ b/server/common/build.gradle.kts
@@ -1,3 +1,4 @@
+import su.plo.voice.extension.excludeKotlin
 import java.net.URI
 
 plugins {
@@ -12,6 +13,16 @@ dependencies {
     api(project(":server-proxy-common"))
 
     compileOnly(libs.netty)
+
+    implementation(libs.micrometer.core)
+    implementation(libs.micrometer.prometheus)
+
+    implementation(libs.http4k.core) {
+        excludeKotlin()
+    }
+    implementation(libs.http4k.jetty) {
+        excludeKotlin()
+    }
 
     testImplementation(libs.mockito)
     testImplementation(libs.netty)

--- a/server/common/src/main/java/su/plo/voice/server/BaseVoiceServer.java
+++ b/server/common/src/main/java/su/plo/voice/server/BaseVoiceServer.java
@@ -4,6 +4,7 @@ import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import su.plo.config.provider.ConfigurationProvider;
 import su.plo.config.provider.toml.TomlConfiguration;
 import su.plo.slib.api.command.McCommand;
@@ -47,6 +48,9 @@ import su.plo.voice.server.connection.ServerServiceChannelHandler;
 import su.plo.voice.server.connection.VoiceTcpServerConnectionManager;
 import su.plo.voice.server.connection.VoiceUdpServerConnectionManager;
 import su.plo.voice.server.language.VoiceServerLanguages;
+import su.plo.voice.server.metrics.Metrics;
+import su.plo.voice.server.metrics.MetricsListener;
+import su.plo.voice.server.metrics.MetricsRejoinListener;
 import su.plo.voice.server.mute.VoiceMuteManager;
 import su.plo.voice.server.mute.storage.MuteStorageFactory;
 import su.plo.voice.server.player.LuckPermsListener;
@@ -63,6 +67,8 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static su.plo.voice.server.metrics.MetricsKt.createPrometheusMetrics;
 
 public abstract class BaseVoiceServer extends BaseVoice implements PlasmoVoiceServer {
 
@@ -105,6 +111,11 @@ public abstract class BaseVoiceServer extends BaseVoice implements PlasmoVoiceSe
 
     private final ServerChannelHandler channelHandler = new ServerChannelHandler(this);
     private final ServerServiceChannelHandler serviceChannelHandler = new ServerServiceChannelHandler(this);
+
+    @Getter
+    private @Nullable Metrics metrics;
+    private @Nullable MetricsListener metricsListener;
+    private @Nullable MetricsRejoinListener metricsRejoinListener;
 
     protected BaseVoiceServer(@NotNull PlatformLoader loader) {
         super(loader);
@@ -192,6 +203,12 @@ public abstract class BaseVoiceServer extends BaseVoice implements PlasmoVoiceSe
         this.config = null;
 
         eventBus.unregister(this);
+
+        if (metrics != null) {
+            if (metricsRejoinListener != null) metricsRejoinListener.unregister();
+            metrics.stop();
+        }
+
         super.onShutdown();
     }
 
@@ -234,7 +251,7 @@ public abstract class BaseVoiceServer extends BaseVoice implements PlasmoVoiceSe
                     UUID forwardingSecret = UUID.fromString(System.getenv("PLASMO_VOICE_FORWARDING_SECRET"));
                     config.host().forwardingSecret(forwardingSecret);
                 } else if (forwardingSecretFile.exists()) {
-                    UUID forwardingSecret = UUID.fromString(new String(Files.readAllBytes(forwardingSecretFile.toPath())));
+                    UUID forwardingSecret = UUID.fromString(new String(Files.readAllBytes(forwardingSecretFile.toPath())).trim());
                     config.host().forwardingSecret(forwardingSecret);
                 }
             } catch (Exception e) {
@@ -277,6 +294,33 @@ public abstract class BaseVoiceServer extends BaseVoice implements PlasmoVoiceSe
 
         if (reload) eventBus.fire(new VoiceServerConfigReloadedEvent(this, config));
         else addons.initializeLoadedAddons();
+
+        // load metrics
+        if (metrics != null) {
+            if (metricsListener != null) eventBus.unregister(this, metricsListener);
+            if (metricsRejoinListener != null) {
+                eventBus.unregister(this, metricsRejoinListener);
+                metricsRejoinListener.unregister();
+            }
+
+            metrics.stop();
+            metrics = null;
+        }
+
+        if (config.metrics().enabled()) {
+            try {
+                metrics = createPrometheusMetrics(config.metrics());
+
+                metricsListener = new MetricsListener(metrics);
+                metricsRejoinListener  = new MetricsRejoinListener(metrics);
+
+                eventBus.register(this, metricsListener);
+                eventBus.register(this, metricsRejoinListener);
+            } catch (Throwable t) {
+                LOGGER.error("Failed to start metrics server", t);
+                metrics = null;
+            }
+        }
 
         if (restartUdpServer) startUdpServer();
     }

--- a/server/common/src/main/java/su/plo/voice/server/config/VoiceServerConfig.java
+++ b/server/common/src/main/java/su/plo/voice/server/config/VoiceServerConfig.java
@@ -63,6 +63,9 @@ public final class VoiceServerConfig implements ServerConfig {
     @ConfigField
     private Voice voice = new Voice();
 
+    @ConfigField
+    private Metrics metrics = new Metrics();
+
     @Config
     @Data
     @Accessors(fluent = true)
@@ -307,5 +310,24 @@ public final class VoiceServerConfig implements ServerConfig {
                 return keepAliveTimeout >= 1_000 && keepAliveTimeout <= 120_000;
             }
         }
+    }
+
+    @Config
+    @Data
+    @Accessors(fluent = true)
+    @EqualsAndHashCode
+    public static class Metrics implements ServerConfig.Metrics {
+        @ConfigField(comment = "Enable prometheus metrics server")
+        private boolean enabled = false;
+
+        @ConfigField
+        private boolean jvmMetrics = false;
+
+        @ConfigField
+        private String ip = "0.0.0.0";
+
+        @ConfigField
+        @ConfigValidator(value = Host.PortValidator.class, allowed = "0-65535")
+        private int port = 24455;
     }
 }

--- a/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpKeepAlive.java
+++ b/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpKeepAlive.java
@@ -7,12 +7,16 @@ import su.plo.voice.api.server.event.connection.UdpClientDisconnectedEvent;
 import su.plo.voice.api.server.socket.UdpServerConnection;
 import su.plo.voice.proto.packets.udp.bothbound.PingPacket;
 import su.plo.voice.server.BaseVoiceServer;
+import su.plo.voice.server.metrics.Metrics;
 
+import java.time.Duration;
 import java.util.Random;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public final class NettyUdpKeepAlive {
+
+    private final static long KEEP_ALIVE_INTERVAL = 2_500L;
 
     private final BaseVoiceServer voiceServer;
 
@@ -41,15 +45,24 @@ public final class NettyUdpKeepAlive {
         long now = System.currentTimeMillis();
         PingPacket packet = new PingPacket();
 
+        Metrics metrics = voiceServer.getMetrics();
+
         for (UdpServerConnection connection : voiceServer.getUdpConnectionManager().getConnections()) {
             if (now - connection.getLastReceivedPacketTimestamp() > voiceServer.getConfig().voice().keepAliveTimeoutMs()) {
                 BaseVoice.DEBUG_LOGGER.log("UDP connection timed out: {}", connection);
                 voiceServer.getUdpConnectionManager().removeConnection(connection, UdpClientDisconnectedEvent.Reason.TIMED_OUT);
                 voiceServer.getTcpPacketManager().requestPlayerInfo(connection.getPlayer());
-            } else if (now - connection.getSentKeepAlive() >= 1_000L) {
-                long jitter = 1_500 + jitterRandom.nextInt(1_500);
-                connection.setSentKeepAlive(now + jitter);
+            } else if (now >= connection.getNextKeepAlive()) {
+                long jitter = jitterRandom.nextInt(1_500);
+                connection.setNextKeepAlive(now + KEEP_ALIVE_INTERVAL + jitter);
+                connection.setSentKeepAlive(now);
+
                 connection.sendPacket(packet);
+            }
+
+            if (metrics != null) {
+                long lag = now - connection.getLastReceivedPacketTimestamp();
+                metrics.recordKeepAliveTimeSeconds(Duration.ofMillis(lag));
             }
         }
     }

--- a/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpServer.java
+++ b/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpServer.java
@@ -20,6 +20,11 @@ import su.plo.voice.BaseVoice;
 import su.plo.voice.api.server.socket.UdpServer;
 import su.plo.voice.proto.packets.PacketDirection;
 import su.plo.voice.server.BaseVoiceServer;
+import su.plo.voice.server.metrics.Metrics;
+import su.plo.voice.server.metrics.NettyPacketExceptionHandlerMetrics;
+import su.plo.voice.server.metrics.NettyPacketHandlerPostDecoderMetrics;
+import su.plo.voice.server.metrics.NettyPacketHandlerPreDecoderMetrics;
+import su.plo.voice.server.metrics.NettyPacketHandlerPreHandlerMetrics;
 import su.plo.voice.socket.NettyExceptionHandler;
 import su.plo.voice.socket.NettyPacketUdpDecoder;
 
@@ -69,6 +74,19 @@ public final class NettyUdpServer implements UdpServer {
                 pipeline.addLast("decoder", new NettyPacketUdpDecoder(PacketDirection.SERVER));
                 pipeline.addLast("handler", new NettyPacketHandler(voiceServer));
                 pipeline.addLast("exception_handler", new NettyExceptionHandler());
+
+                Metrics metrics = voiceServer.getMetrics();
+                if (metrics != null) {
+                    metrics.attachNettyAllocatorMetrics(pipeline.channel().alloc());
+                    metrics.attachNettyExecutorMetrics(loopGroup);
+
+                    pipeline.addBefore("handler", "metrics_pre_handler", new NettyPacketHandlerPreHandlerMetrics(voiceServer));
+
+                    pipeline.addBefore("decoder", "metrics_pre_decoder", new NettyPacketHandlerPreDecoderMetrics(voiceServer));
+                    pipeline.addAfter("decoder", "metrics_post_decoder", new NettyPacketHandlerPostDecoderMetrics(voiceServer));
+
+                    pipeline.addBefore("exception_handler", "metrics_exception_handler", new NettyPacketExceptionHandlerMetrics(voiceServer, Metrics.PacketHandlerErrorStage.Decode));
+                }
             }
         });
 

--- a/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpServer.java
+++ b/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpServer.java
@@ -3,6 +3,7 @@ package su.plo.voice.server.socket;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
@@ -72,8 +73,9 @@ public final class NettyUdpServer implements UdpServer {
                 ChannelPipeline pipeline = ch.pipeline();
 
                 pipeline.addLast("decoder", new NettyPacketUdpDecoder(PacketDirection.SERVER));
+                pipeline.addLast("decoder_exception_handler", new NettyExceptionHandler("Failed to decode packet"));
                 pipeline.addLast("handler", new NettyPacketHandler(voiceServer));
-                pipeline.addLast("exception_handler", new NettyExceptionHandler());
+                pipeline.addLast("handler_exception_handler", new NettyExceptionHandler());
 
                 Metrics metrics = voiceServer.getMetrics();
                 if (metrics != null) {
@@ -85,7 +87,24 @@ public final class NettyUdpServer implements UdpServer {
                     pipeline.addBefore("decoder", "metrics_pre_decoder", new NettyPacketHandlerPreDecoderMetrics(voiceServer));
                     pipeline.addAfter("decoder", "metrics_post_decoder", new NettyPacketHandlerPostDecoderMetrics(voiceServer));
 
-                    pipeline.addBefore("exception_handler", "metrics_exception_handler", new NettyPacketExceptionHandlerMetrics(voiceServer, Metrics.PacketHandlerErrorStage.Decode));
+                    pipeline.replace(
+                            "decoder_exception_handler",
+                            "decoder_exception_handler",
+                            new NettyPacketExceptionHandlerMetrics(
+                                    voiceServer,
+                                    Metrics.PacketHandlerErrorStage.Decode,
+                                    (ChannelInboundHandler) pipeline.get("decoder_exception_handler")
+                            )
+                    );
+                    pipeline.replace(
+                            "handler_exception_handler",
+                            "handler_exception_handler",
+                            new NettyPacketExceptionHandlerMetrics(
+                                    voiceServer,
+                                    Metrics.PacketHandlerErrorStage.Handle,
+                                    (ChannelInboundHandler) pipeline.get("handler_exception_handler")
+                            )
+                    );
                 }
             }
         });

--- a/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpServerConnection.java
+++ b/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpServerConnection.java
@@ -24,6 +24,7 @@ import su.plo.voice.proto.packets.udp.serverbound.ServerPacketUdpHandler;
 import su.plo.voice.server.BaseVoiceServer;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.UUID;
 
 @ToString(of = {"channel", "secret", "player", "keepAlive", "sentKeepAlive"})
@@ -41,11 +42,16 @@ public final class NettyUdpServerConnection implements UdpServerConnection, Serv
     private final UUID secret;
     @Getter
     private final VoiceServerPlayer player;
+
     @Getter
     private long keepAlive = System.currentTimeMillis();
     @Getter
     @Setter
     private long sentKeepAlive;
+    @Getter
+    @Setter
+    private long nextKeepAlive;
+
     @Getter
     private long lastReceivedPacketTimestamp = System.currentTimeMillis();
 
@@ -82,7 +88,7 @@ public final class NettyUdpServerConnection implements UdpServerConnection, Serv
         ByteBuf buf = Unpooled.wrappedBuffer(encoded);
         channel.writeAndFlush(new DatagramPacket(buf, remoteAddress));
 
-        voiceServer.getEventBus().fire(new UdpPacketSentEvent(this, packet));
+        voiceServer.getEventBus().fire(new UdpPacketSentEvent(this, packet, encoded.length));
     }
 
     @Override
@@ -104,6 +110,10 @@ public final class NettyUdpServerConnection implements UdpServerConnection, Serv
     @Override
     public void handle(@NotNull PingPacket packet) {
         this.keepAlive = System.currentTimeMillis();
+
+        if (voiceServer.getMetrics() != null) {
+            voiceServer.getMetrics().recordRtt(Duration.ofMillis(keepAlive - sentKeepAlive));
+        }
     }
 
     @Override

--- a/server/common/src/main/kotlin/su/plo/voice/server/audio/capture/ProximityServerActivation.kt
+++ b/server/common/src/main/kotlin/su/plo/voice/server/audio/capture/ProximityServerActivation.kt
@@ -4,16 +4,16 @@ import su.plo.slib.api.permission.PermissionDefault
 import su.plo.voice.api.event.EventSubscribe
 import su.plo.voice.api.server.PlasmoVoiceServer
 import su.plo.voice.api.server.audio.capture.ProximityServerActivationHelper
+import su.plo.voice.api.server.config.ServerConfig
 import su.plo.voice.api.server.event.player.PlayerActivationDistanceUpdateEvent
 import su.plo.voice.proto.data.audio.capture.VoiceActivation
 import su.plo.voice.proto.data.audio.line.VoiceSourceLine
-import su.plo.voice.server.config.VoiceServerConfig
 
 class ProximityServerActivation(private val voiceServer: PlasmoVoiceServer) {
 
     private var proximityHelper: ProximityServerActivationHelper? = null
 
-    fun register(config: VoiceServerConfig) {
+    fun register(config: ServerConfig) {
         proximityHelper?.let {
             it.unregisterListeners(voiceServer)
             voiceServer.activationManager.unregister(it.activation)
@@ -29,7 +29,7 @@ class ProximityServerActivation(private val voiceServer: PlasmoVoiceServer) {
             1
         )
         val activation = builder
-            .setDistances(config.voice().proximity().distances())
+            .setDistances(config.voice().proximity().distances().toList())
             .setDefaultDistance(config.voice().proximity().defaultDistance())
             .setProximity(true)
             .setTransitive(true)

--- a/server/common/src/main/kotlin/su/plo/voice/server/metrics/Metrics.kt
+++ b/server/common/src/main/kotlin/su/plo/voice/server/metrics/Metrics.kt
@@ -97,6 +97,7 @@ class Metrics(
         val stage: String,
     ) {
         Decode("decode"),
+        Handle("handle"),
     }
 
     private val activePeerGauges = Maps.newConcurrentMap<String, AtomicInteger>()
@@ -150,7 +151,7 @@ class Metrics(
 
     init {
         PacketHandlerErrorStage.entries.forEach {
-            Counter.builder("pv_decode_errors_total")
+            Counter.builder("pv_pipeline_errors_total")
                 .tag("stage", it.stage)
                 .register(registry)
         }
@@ -236,10 +237,10 @@ class Metrics(
         ).increment()
     }
 
-    // pv_decode_errors_total{stage="decode"}
+    // pv_pipeline_errors_total{stage="decode|handle"}
     fun handlerError(stage: PacketHandlerErrorStage) {
         registry.counter(
-            "pv_decode_errors_total",
+            "pv_pipeline_errors_total",
             "stage", stage.stage,
         ).increment()
     }

--- a/server/common/src/main/kotlin/su/plo/voice/server/metrics/Metrics.kt
+++ b/server/common/src/main/kotlin/su/plo/voice/server/metrics/Metrics.kt
@@ -202,6 +202,7 @@ class Metrics(
     // pv_active_peers{public_ip="127.0.0.1"}
     fun gaugeActivePeer(publicIp: String, number: Int): Int {
         val gauge = activePeerGauges.computeIfAbsent(publicIp) {
+            initPublicIpMetrics(publicIp)
             registry.gauge(
                 "pv_active_peers",
                 Tags.of("public_ip", publicIp),
@@ -245,6 +246,23 @@ class Metrics(
 
     fun stop() {
         httpServer.stop()
+    }
+
+    private fun initPublicIpMetrics(publicIp: String) {
+        registry.counter(
+            "pv_hard_timeouts_total",
+            "public_ip", publicIp,
+        )
+
+        registry.counter(
+            "pv_rejoin_attempts_total",
+            "public_ip", publicIp,
+        )
+
+        registry.counter(
+            "pv_rejoin_success_total",
+            "public_ip", publicIp,
+        )
     }
 }
 

--- a/server/common/src/main/kotlin/su/plo/voice/server/metrics/Metrics.kt
+++ b/server/common/src/main/kotlin/su/plo/voice/server/metrics/Metrics.kt
@@ -1,0 +1,256 @@
+package su.plo.voice.server.metrics
+
+import com.google.common.collect.Maps
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tags
+import io.micrometer.core.instrument.Timer
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmThreadDeadlockMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
+import io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics
+import io.micrometer.core.instrument.binder.netty4.NettyEventExecutorMetrics
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import io.netty.buffer.ByteBufAllocator
+import io.netty.buffer.ByteBufAllocatorMetricProvider
+import io.netty.util.concurrent.EventExecutor
+import org.eclipse.jetty.server.Server
+import org.http4k.core.Method
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.OK
+import org.http4k.routing.bind
+import org.http4k.routing.routes
+import org.http4k.server.Http4kServer
+import org.http4k.server.Jetty
+import org.http4k.server.asServer
+import su.plo.voice.BaseVoice
+import su.plo.voice.api.server.config.ServerConfig
+import su.plo.voice.proto.packets.Packet
+import su.plo.voice.proto.packets.udp.bothbound.PingPacket
+import java.net.InetSocketAddress
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+fun createPrometheusMetrics(config: ServerConfig.Metrics): Metrics {
+    val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+
+    if (config.jvmMetrics()) {
+        ClassLoaderMetrics().bindTo(registry)
+        JvmMemoryMetrics().bindTo(registry)
+        JvmGcMetrics().bindTo(registry)
+        ProcessorMetrics().bindTo(registry)
+        JvmThreadMetrics().bindTo(registry)
+        JvmThreadDeadlockMetrics().bindTo(registry)
+    }
+
+    val app = routes(
+        "/metrics" bind Method.GET to {
+            Response(OK)
+                .header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+                .body(registry.scrape())
+        }
+    )
+
+    val jettyServer =
+        if (config.ip() != "0.0.0.0") {
+            Server(InetSocketAddress(config.ip(), config.port()))
+        } else {
+            Server(config.port())
+        }
+    val server = app.asServer(
+        Jetty(
+            port = config.port(),
+            server = jettyServer,
+        )
+    ).start()
+
+    BaseVoice.LOGGER.info("Prometheus exporter started on :${server.port()}")
+
+    return Metrics(config, registry, server)
+}
+
+class Metrics(
+    private val config: ServerConfig.Metrics,
+    private val registry: MeterRegistry,
+    private val httpServer: Http4kServer,
+) {
+
+    enum class PacketDirection(
+        val direction: String,
+    ) {
+        In("in"),
+        Out("out"),
+    }
+
+    enum class PacketKind(
+        val kind: String,
+    ) {
+        Media("media"),
+        Control("control"),
+    }
+
+    enum class PacketHandlerErrorStage(
+        val stage: String,
+    ) {
+        Decode("decode"),
+    }
+
+    private val activePeerGauges = Maps.newConcurrentMap<String, AtomicInteger>()
+
+    // pv_handler_time_seconds histo
+    // buckets: 0.0005,0.001,0.002,0.005,0.01,0.02,0.05,0.1
+    private val handlerTimeSeconds: Timer = Timer.builder("pv_handler_time_seconds")
+        .publishPercentileHistogram(true)
+        .sla(
+            *listOf(0.0005, 0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1)
+                .map { (it * 1e9).toLong() }
+                .map { Duration.ofNanos(it) }
+                .toTypedArray()
+        )
+        .register(registry)
+
+    // pv_pipeline_time_seconds histo
+    // buckets: 0.0005,0.001,0.002,0.005,0.01,0.02,0.05,0.1
+    private val pipelineTimeSeconds: Timer = Timer.builder("pv_pipeline_time_seconds")
+        .publishPercentileHistogram(true)
+        .sla(
+            *listOf(0.0005, 0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1)
+                .map { (it * 1e9).toLong() }
+                .map { Duration.ofNanos(it) }
+                .toTypedArray()
+        )
+        .register(registry)
+
+    // pv_keep_alive_lag_seconds histo
+    // buckets:
+    private val keepAliveLagSeconds: Timer = Timer.builder("pv_keep_alive_lag_seconds")
+        .publishPercentileHistogram(true)
+        .sla(
+            *listOf(0.2, 0.5, 1.0, 2.0, 3.0, 5.0, 8.0, 13.0)
+                .map { (it * 1e9).toLong() }
+                .map { Duration.ofNanos(it) }
+                .toTypedArray()
+        )
+        .register(registry)
+
+    // pv_rtt_seconds histo
+    private val rttSeconds: Timer = Timer.builder("pv_rtt_seconds")
+        .publishPercentileHistogram(true)
+        .sla(
+            *listOf(0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0)
+                .map { (it * 1e9).toLong() }
+                .map { Duration.ofNanos(it) }
+                .toTypedArray()
+        )
+        .register(registry)
+
+    init {
+        PacketHandlerErrorStage.entries.forEach {
+            Counter.builder("pv_decode_errors_total")
+                .tag("stage", it.stage)
+                .register(registry)
+        }
+    }
+
+    fun recordHandlerTimeSeconds(duration: Duration) {
+        handlerTimeSeconds.record(duration)
+    }
+
+    fun recordPipelineTimeSeconds(duration: Duration) {
+        pipelineTimeSeconds.record(duration)
+    }
+
+    fun recordKeepAliveTimeSeconds(duration: Duration) {
+        keepAliveLagSeconds.record(duration)
+    }
+
+    fun recordRtt(duration: Duration) {
+        rttSeconds.record(duration)
+    }
+
+    fun attachNettyAllocatorMetrics(alloc: ByteBufAllocator) {
+        if (config.jvmMetrics()) {
+            NettyAllocatorMetrics(alloc as ByteBufAllocatorMetricProvider).bindTo(registry)
+        }
+    }
+
+    fun attachNettyExecutorMetrics(eventExecutor: Iterable<EventExecutor>) {
+        if (config.jvmMetrics()) {
+            NettyEventExecutorMetrics(eventExecutor).bindTo(registry)
+        }
+    }
+
+    // pv_udp_packets_total{dir="in|out",kind="media|control"}
+    fun recordPacket(direction: PacketDirection, kind: PacketKind, bytes: Int) {
+        registry.counter(
+            "pv_udp_packets_total",
+            "dir", direction.direction,
+            "kind", kind.kind
+        ).increment()
+
+        registry.counter(
+            "pv_udp_bytes_total",
+            "dir", direction.direction,
+            "kind", kind.kind
+        ).increment(bytes.toDouble())
+    }
+
+    // pv_active_peers{public_ip="127.0.0.1"}
+    fun gaugeActivePeer(publicIp: String, number: Int): Int {
+        val gauge = activePeerGauges.computeIfAbsent(publicIp) {
+            registry.gauge(
+                "pv_active_peers",
+                Tags.of("public_ip", publicIp),
+                AtomicInteger(0)
+            )
+        }
+        return gauge.addAndGet(number)
+    }
+
+    // pv_hard_timeouts_total{public_ip="127.0.0.1"}
+    fun hardTimeout(publicIp: String) {
+        registry.counter(
+            "pv_hard_timeouts_total",
+            "public_ip", publicIp,
+        ).increment()
+    }
+
+    // pv_rejoin_attempts_total{public_ip="127.0.0.1"}
+    fun rejoinAttempt(publicIp: String) {
+        registry.counter(
+            "pv_rejoin_attempts_total",
+            "public_ip", publicIp,
+        ).increment()
+    }
+
+    // pv_rejoin_success_total{public_ip="127.0.0.1"}
+    fun rejoinSuccess(publicIp: String) {
+        registry.counter(
+            "pv_rejoin_success_total",
+            "public_ip", publicIp,
+        ).increment()
+    }
+
+    // pv_decode_errors_total{stage="decode"}
+    fun handlerError(stage: PacketHandlerErrorStage) {
+        registry.counter(
+            "pv_decode_errors_total",
+            "stage", stage.stage,
+        ).increment()
+    }
+
+    fun stop() {
+        httpServer.stop()
+    }
+}
+
+internal fun getPacketKind(packet: Packet<*>): Metrics.PacketKind =
+    if (packet is PingPacket) {
+        Metrics.PacketKind.Control
+    } else {
+        Metrics.PacketKind.Media
+    }

--- a/server/common/src/main/kotlin/su/plo/voice/server/metrics/Metrics.kt
+++ b/server/common/src/main/kotlin/su/plo/voice/server/metrics/Metrics.kt
@@ -151,9 +151,20 @@ class Metrics(
 
     init {
         PacketHandlerErrorStage.entries.forEach {
-            Counter.builder("pv_pipeline_errors_total")
-                .tag("stage", it.stage)
-                .register(registry)
+            registry.counter(
+                "pv_pipeline_errors_total",
+                "stage", it.stage,
+            )
+        }
+
+        PacketDirection.entries.forEach { direction ->
+            PacketKind.entries.forEach { kind ->
+                registry.counter(
+                    "pv_udp_packets_total",
+                    "dir", direction.direction,
+                    "kind", kind.kind,
+                )
+            }
         }
     }
 

--- a/server/common/src/main/kotlin/su/plo/voice/server/metrics/Metrics.kt
+++ b/server/common/src/main/kotlin/su/plo/voice/server/metrics/Metrics.kt
@@ -18,6 +18,8 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import io.netty.buffer.ByteBufAllocator
 import io.netty.buffer.ByteBufAllocatorMetricProvider
 import io.netty.util.concurrent.EventExecutor
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap
 import org.eclipse.jetty.server.Server
 import org.http4k.core.Method
 import org.http4k.core.Response
@@ -100,6 +102,9 @@ class Metrics(
         Handle("handle"),
     }
 
+    private infix fun PacketDirection.of(kind: PacketKind): Int =
+        this.ordinal + (kind.ordinal shl 1)
+
     private val activePeerGauges = Maps.newConcurrentMap<String, AtomicInteger>()
 
     // pv_handler_time_seconds histo
@@ -149,22 +154,46 @@ class Metrics(
         )
         .register(registry)
 
+    private val udpPacketsTotal: Int2ObjectMap<Counter> = Int2ObjectArrayMap(
+        PacketDirection.entries.flatMap { direction ->
+            PacketKind.entries.map { kind ->
+                direction to kind
+            }
+        }
+            .associate {
+                val key = it.first.ordinal + (it.second.ordinal shl 1)
+
+                key to registry.counter(
+                    "pv_udp_packets_total",
+                    "dir", it.first.direction,
+                    "kind", it.second.kind,
+                )
+            }
+    )
+
+    private val udpBytesTotal: Int2ObjectMap<Counter> = Int2ObjectArrayMap(
+        PacketDirection.entries.flatMap { direction ->
+            PacketKind.entries.map { kind ->
+                direction to kind
+            }
+        }
+            .associate {
+                val key = it.first of it.second
+
+                key to registry.counter(
+                    "pv_udp_bytes_total",
+                    "dir", it.first.direction,
+                    "kind", it.second.kind,
+                )
+            }
+    )
+
     init {
         PacketHandlerErrorStage.entries.forEach {
             registry.counter(
                 "pv_pipeline_errors_total",
                 "stage", it.stage,
             )
-        }
-
-        PacketDirection.entries.forEach { direction ->
-            PacketKind.entries.forEach { kind ->
-                registry.counter(
-                    "pv_udp_packets_total",
-                    "dir", direction.direction,
-                    "kind", kind.kind,
-                )
-            }
         }
     }
 
@@ -198,17 +227,10 @@ class Metrics(
 
     // pv_udp_packets_total{dir="in|out",kind="media|control"}
     fun recordPacket(direction: PacketDirection, kind: PacketKind, bytes: Int) {
-        registry.counter(
-            "pv_udp_packets_total",
-            "dir", direction.direction,
-            "kind", kind.kind
-        ).increment()
+        val key = direction of kind
 
-        registry.counter(
-            "pv_udp_bytes_total",
-            "dir", direction.direction,
-            "kind", kind.kind
-        ).increment(bytes.toDouble())
+        udpPacketsTotal[key].increment()
+        udpBytesTotal[key].increment(bytes.toDouble())
     }
 
     // pv_active_peers{public_ip="127.0.0.1"}

--- a/server/common/src/main/kotlin/su/plo/voice/server/metrics/MetricsListener.kt
+++ b/server/common/src/main/kotlin/su/plo/voice/server/metrics/MetricsListener.kt
@@ -1,0 +1,33 @@
+package su.plo.voice.server.metrics
+
+import su.plo.voice.api.event.EventSubscribe
+import su.plo.voice.api.server.event.connection.UdpClientConnectEvent
+import su.plo.voice.api.server.event.connection.UdpClientDisconnectedEvent
+import su.plo.voice.api.server.event.connection.UdpPacketSentEvent
+
+class MetricsListener(
+    private val metrics: Metrics,
+) {
+    @EventSubscribe
+    fun onUdpPacketSend(event: UdpPacketSentEvent) {
+        metrics.recordPacket(Metrics.PacketDirection.Out, getPacketKind(event.packet), event.packetEncodedSize)
+    }
+
+    @EventSubscribe
+    fun onUdpClientConnect(event: UdpClientConnectEvent) {
+        val connection = event.connection
+        val publicIp = connection.connectionAddress?.hostString ?: "unknown"
+        metrics.gaugeActivePeer(publicIp, 1)
+    }
+
+    @EventSubscribe
+    fun onUdpClientDisconnect(event: UdpClientDisconnectedEvent) {
+        val connection = event.connection
+        val publicIp = connection.connectionAddress?.hostString ?: "unknown"
+        metrics.gaugeActivePeer(publicIp, -1)
+
+        if (event.reason == UdpClientDisconnectedEvent.Reason.TIMED_OUT) {
+            metrics.hardTimeout(publicIp)
+        }
+    }
+}

--- a/server/common/src/main/kotlin/su/plo/voice/server/metrics/MetricsRejoinListener.kt
+++ b/server/common/src/main/kotlin/su/plo/voice/server/metrics/MetricsRejoinListener.kt
@@ -1,0 +1,49 @@
+package su.plo.voice.server.metrics
+
+import com.google.common.collect.Sets
+import su.plo.slib.api.entity.player.McPlayer
+import su.plo.slib.api.event.player.McPlayerQuitEvent
+import su.plo.voice.api.event.EventPriority
+import su.plo.voice.api.event.EventSubscribe
+import su.plo.voice.api.server.event.connection.TcpPacketSendEvent
+import su.plo.voice.api.server.event.connection.UdpClientConnectEvent
+import su.plo.voice.proto.packets.tcp.clientbound.ConnectionPacket
+import java.util.UUID
+
+class MetricsRejoinListener(
+    private val metrics: Metrics,
+) {
+
+    private val connectedPrior = Sets.newConcurrentHashSet<UUID>()
+
+    init {
+        McPlayerQuitEvent.registerListener(this::onPlayerQuit)
+    }
+
+    fun unregister() {
+        McPlayerQuitEvent.unregisterListener(this::onPlayerQuit)
+    }
+
+    @EventSubscribe(priority = EventPriority.HIGHEST)
+    fun onPacketSend(event: TcpPacketSendEvent) {
+        val packet = event.packet as? ConnectionPacket ?: return
+
+        if (!connectedPrior.contains(event.player.instance.uuid)) return
+
+        metrics.rejoinAttempt(packet.ip)
+    }
+
+    @EventSubscribe
+    fun onUdpClientConnect(event: UdpClientConnectEvent) {
+        val player = event.connection.player
+        if (connectedPrior.add(player.instance.uuid)) return
+
+        val connection = event.connection
+        val publicIp = connection.connectionAddress?.hostString ?: "unknown"
+        metrics.rejoinSuccess(publicIp)
+    }
+
+    private fun onPlayerQuit(player: McPlayer) {
+        connectedPrior.remove(player.uuid)
+    }
+}

--- a/server/common/src/main/kotlin/su/plo/voice/server/metrics/NettyMetricsHandlers.kt
+++ b/server/common/src/main/kotlin/su/plo/voice/server/metrics/NettyMetricsHandlers.kt
@@ -1,0 +1,53 @@
+package su.plo.voice.server.metrics
+
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
+import io.netty.channel.SimpleChannelInboundHandler
+import io.netty.channel.socket.DatagramPacket
+import su.plo.voice.server.BaseVoiceServer
+import su.plo.voice.socket.NettyPacketUdp
+import java.time.Duration
+import kotlin.system.measureNanoTime
+
+class NettyPacketExceptionHandlerMetrics(
+    private val voiceServer: BaseVoiceServer,
+    private val stage: Metrics.PacketHandlerErrorStage,
+) : ChannelInboundHandlerAdapter() {
+    override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable?) {
+        voiceServer.metrics?.handlerError(stage)
+        super.exceptionCaught(ctx, cause)
+    }
+}
+
+class NettyPacketHandlerPreDecoderMetrics(
+    private val voiceServer: BaseVoiceServer,
+) : SimpleChannelInboundHandler<DatagramPacket>(false) {
+    override fun channelRead0(ctx: ChannelHandlerContext, packet: DatagramPacket) {
+        val duration = measureNanoTime { ctx.fireChannelRead(packet) }
+
+        voiceServer.metrics?.recordPipelineTimeSeconds(Duration.ofNanos(duration))
+    }
+}
+
+class NettyPacketHandlerPreHandlerMetrics(
+    private val voiceServer: BaseVoiceServer,
+) : SimpleChannelInboundHandler<NettyPacketUdp>(false) {
+    override fun channelRead0(ctx: ChannelHandlerContext, packet: NettyPacketUdp) {
+        val duration = measureNanoTime { ctx.fireChannelRead(packet) }
+
+        voiceServer.metrics?.recordHandlerTimeSeconds(Duration.ofNanos(duration))
+    }
+}
+
+class NettyPacketHandlerPostDecoderMetrics(
+    private val voiceServer: BaseVoiceServer,
+) : SimpleChannelInboundHandler<NettyPacketUdp>(false) {
+    override fun channelRead0(ctx: ChannelHandlerContext, nettyPacket: NettyPacketUdp) {
+        voiceServer.metrics?.recordPacket(
+            Metrics.PacketDirection.In,
+            getPacketKind(nettyPacket.packetUdp.packetUntyped),
+            nettyPacket.datagramPacket.content().readableBytes(),
+        )
+        ctx.fireChannelRead(nettyPacket)
+    }
+}

--- a/server/common/src/main/kotlin/su/plo/voice/server/metrics/NettyMetricsHandlers.kt
+++ b/server/common/src/main/kotlin/su/plo/voice/server/metrics/NettyMetricsHandlers.kt
@@ -1,9 +1,11 @@
 package su.plo.voice.server.metrics
 
 import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandler
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.channel.SimpleChannelInboundHandler
 import io.netty.channel.socket.DatagramPacket
+import su.plo.voice.BaseVoice
 import su.plo.voice.server.BaseVoiceServer
 import su.plo.voice.socket.NettyPacketUdp
 import java.time.Duration
@@ -12,10 +14,11 @@ import kotlin.system.measureNanoTime
 class NettyPacketExceptionHandlerMetrics(
     private val voiceServer: BaseVoiceServer,
     private val stage: Metrics.PacketHandlerErrorStage,
+    private val originalHandler: ChannelInboundHandler,
 ) : ChannelInboundHandlerAdapter() {
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable?) {
         voiceServer.metrics?.handlerError(stage)
-        super.exceptionCaught(ctx, cause)
+        originalHandler.exceptionCaught(ctx, cause)
     }
 }
 

--- a/server/common/src/test/kotlin/MockClient.kt
+++ b/server/common/src/test/kotlin/MockClient.kt
@@ -184,6 +184,8 @@ class MockClientConnection(
     }
 
     override fun handle(packet: PlayerInfoRequestPacket) {
+        udpClient?.close()
+        udpClient = null
         sendPacket(
             PlayerInfoPacket(
                 "1.0.0",


### PR DESCRIPTION
Currently metrics are only available server-side: Spigot-based, Minestom, Fabric, Forge, NeoForge.
Proxy-side (Velocity, BungeeCord) is planned.

## Configuration

Metrics are disabled by default:

```toml
[metrics]
enabled = false
# Include JVM and Netty metrics (heap, threads, GC, event loops, etc.)
jvm_metrics = false
ip = "0.0.0.0"
port = 24455
```

## Metrics

**Histograms**:
- `pv_handler_time_seconds` - Packet handler processing time (buckets: 0.5ms to 100ms)
- `pv_pipeline_time_seconds` - Full pipeline processing time (buckets: 0.5ms to 100ms)
- `pv_keep_alive_lag_seconds` - Keep-alive packet lag/delay (buckets: 0.2s to 13s)
- `pv_rtt_seconds` - Round-trip time for pings (buckets: 10ms to 2s)

**Counters**:
- `pv_udp_packets_total{dir="in|out", kind="media|control"}` - Total UDP packets by direction and type
- `pv_udp_bytes_total{dir="in|out", kind="media|control"}` - Total UDP bytes by direction and type
- `pv_hard_timeouts_total{public_ip="..."}` - Client timeouts per public IP
- `pv_rejoin_attempts_total{public_ip="..."}` - Client rejoin attempts per public IP
- `pv_rejoin_success_total{public_ip="..."}` - Successful rejoins per public IP
- `pv_pipeline_errors_total{stage="decode|handle"}` - UDP pipeline errors by stage

**Gauges**:
- `pv_active_peers{public_ip="..."}` - Active connections per public IP

## Download

https://artifacts.plasmoverse.com/projects/plasmo-voice/branches/feat%2Fmetrics