### PR TITLE
Add ability to cap extra packet transmit distance

### DIFF
--- a/api/server/src/main/java/su/plo/voice/api/server/config/ServerConfig.java
+++ b/api/server/src/main/java/su/plo/voice/api/server/config/ServerConfig.java
@@ -54,6 +54,8 @@ public interface ServerConfig {
          */
         byte[] aesEncryptionKey();
 
+        int maxExtraAudioBroadcastDistance();
+
         int sampleRate();
 
         int keepAliveTimeoutMs();

--- a/server/common/src/main/java/su/plo/voice/server/config/VoiceServerConfig.java
+++ b/server/common/src/main/java/su/plo/voice/server/config/VoiceServerConfig.java
@@ -118,6 +118,9 @@ public final class VoiceServerConfig implements ServerConfig {
 
         private byte[] aesEncryptionKey = null;
 
+        @ConfigField(comment = "The maximum amount, in blocks, to broadcast audio packets past the audible proximity distance.\nThe plugin will send audio packets to players within 2x the proximity distance, or the distance plus this number - whichever is smaller.")
+        private int maxExtraAudioBroadcastDistance = 16;
+
         @ConfigField(comment = "Supported sample rates: [8000, 12000, 24000, 48000]\nDon't change this to reduce bandwidth; adjust opus bitrate instead")
         @ConfigValidator(
                 value = SampleRateValidator.class,

--- a/server/common/src/main/kotlin/su/plo/voice/server/audio/source/VoiceServerProximitySource.kt
+++ b/server/common/src/main/kotlin/su/plo/voice/server/audio/source/VoiceServerProximitySource.kt
@@ -18,6 +18,7 @@ import su.plo.voice.proto.packets.udp.clientbound.SourceAudioPacket
 import java.util.UUID
 import java.util.function.Supplier
 import kotlin.math.max
+import kotlin.math.min
 
 abstract class VoiceServerProximitySource<S : SourceInfo>(
     private val voiceServer: PlasmoVoiceServer,
@@ -43,7 +44,7 @@ abstract class VoiceServerProximitySource<S : SourceInfo>(
         // update packet's source state
         packet.sourceState = state.get().toByte()
 
-        val listenersDistance = max(event.distance + voiceServer.config!!.voice().maxExtraAudioBroadcastDistance(), event.distance * DISTANCE_MULTIPLIER)
+        val listenersDistance = min(event.distance + voiceServer.config!!.voice().maxExtraAudioBroadcastDistance(), event.distance * DISTANCE_MULTIPLIER)
 
         // update source info on listeners if source is dirty
         if (dirty.compareAndSet(true, false)) {
@@ -74,7 +75,7 @@ abstract class VoiceServerProximitySource<S : SourceInfo>(
         if (!voiceServer.eventBus.fire(event)) return false
         if (event.result == ServerSourcePacketEvent.Result.HANDLED) return true
 
-        val listenersDistance = event.distance * DISTANCE_MULTIPLIER
+        val listenersDistance = min(event.distance + voiceServer.config!!.voice().maxExtraAudioBroadcastDistance(), event.distance * DISTANCE_MULTIPLIER)
 
         val playerPosition = ServerPos3d()
         val sourcePosition = position

--- a/server/common/src/main/kotlin/su/plo/voice/server/audio/source/VoiceServerProximitySource.kt
+++ b/server/common/src/main/kotlin/su/plo/voice/server/audio/source/VoiceServerProximitySource.kt
@@ -17,6 +17,7 @@ import su.plo.voice.proto.packets.tcp.clientbound.SourceInfoPacket
 import su.plo.voice.proto.packets.udp.clientbound.SourceAudioPacket
 import java.util.UUID
 import java.util.function.Supplier
+import kotlin.math.max
 
 abstract class VoiceServerProximitySource<S : SourceInfo>(
     private val voiceServer: PlasmoVoiceServer,
@@ -42,7 +43,7 @@ abstract class VoiceServerProximitySource<S : SourceInfo>(
         // update packet's source state
         packet.sourceState = state.get().toByte()
 
-        val listenersDistance = event.distance * DISTANCE_MULTIPLIER
+        val listenersDistance = max(event.distance + voiceServer.config!!.voice().maxExtraAudioBroadcastDistance(), event.distance * DISTANCE_MULTIPLIER)
 
         // update source info on listeners if source is dirty
         if (dirty.compareAndSet(true, false)) {

--- a/server/common/src/main/kotlin/su/plo/voice/server/audio/source/VoiceServerProximitySource.kt
+++ b/server/common/src/main/kotlin/su/plo/voice/server/audio/source/VoiceServerProximitySource.kt
@@ -17,7 +17,6 @@ import su.plo.voice.proto.packets.tcp.clientbound.SourceInfoPacket
 import su.plo.voice.proto.packets.udp.clientbound.SourceAudioPacket
 import java.util.UUID
 import java.util.function.Supplier
-import kotlin.math.max
 import kotlin.math.min
 
 abstract class VoiceServerProximitySource<S : SourceInfo>(


### PR DESCRIPTION
On the SMP I run, we had players spying on each other by taking advantage of a freecam mod to monitor in-game voice communication from a distance. We have an activation distance option configured of 32 blocks, which allows for players as far as 4 chunks away to hear conversations going on elsewhere when enabled.

This PR introduces the following section to `config.toml`
```toml
[voice]
# The maximum amount, in blocks, to broadcast audio packets past the audible proximity distance.
# The plugin will send audio packets to players within 2x the proximity distance, or the distance plus this number - whichever is smaller.
max_extra_audio_broadcast_distance = 16
```

This defaults to 16, but can be set to 0 or negative amounts if needed to work around the voice fall-off range depending on someone's setup. This setting caps the packets sent to only be `max(distance + max_extra_audio_broadcast_distance, distance * 2)` effectively. It may be worth adding a config for that multiplier as well after merging this.