### PR TITLE
Config option to make vmute/vunmute commands and mute expirations silent

### DIFF
--- a/api/server/src/main/java/su/plo/voice/api/server/config/ServerConfig.java
+++ b/api/server/src/main/java/su/plo/voice/api/server/config/ServerConfig.java
@@ -26,6 +26,15 @@ public interface ServerConfig {
 
     @NotNull Voice voice();
 
+    @NotNull Notifications notifications();
+
+    interface Notifications {
+
+        boolean muted();
+
+        boolean unmuted();
+    }
+
     interface Host {
 
         @NotNull String ip();

--- a/api/server/src/main/java/su/plo/voice/api/server/mute/ServerMuteInfo.java
+++ b/api/server/src/main/java/su/plo/voice/api/server/mute/ServerMuteInfo.java
@@ -17,6 +17,21 @@ public class ServerMuteInfo {
     private final long mutedAtTime;
     private final long mutedToTime;
     private final @Nullable String reason;
+    private final @Nullable Boolean silent;
+
+    /**
+     * Backward-compatible constructor that leaves {@link #getSilent()} unspecified (null).
+     *
+     * @deprecated use {@link #ServerMuteInfo(UUID, UUID, long, long, String, Boolean)}.
+     */
+    @Deprecated
+    public ServerMuteInfo(@NotNull UUID playerUUID,
+                          @Nullable UUID mutedByPlayerUUID,
+                          long mutedAtTime,
+                          long mutedToTime,
+                          @Nullable String reason) {
+        this(playerUUID, mutedByPlayerUUID, mutedAtTime, mutedToTime, reason, null);
+    }
 
     /**
      * Gets the UUID of the player who is muted.
@@ -61,5 +76,17 @@ public class ServerMuteInfo {
      */
     public @Nullable String getReason() {
         return reason;
+    }
+
+    /**
+     * Gets whether the player was muted silently, i.e. without receiving a notification.
+     *
+     * @return {@code true}/{@code false} if specified at mute time,
+     * or {@code null} if unspecified (e.g. mutes stored before this field existed).
+     * The expiry ticker treats {@code null} by falling back to the server's
+     * {@code notifications.unmuted} config value.
+     */
+    public @Nullable Boolean getSilent() {
+        return silent;
     }
 }

--- a/server/common/src/main/java/su/plo/voice/server/command/VoiceMuteCommand.java
+++ b/server/common/src/main/java/su/plo/voice/server/command/VoiceMuteCommand.java
@@ -110,7 +110,7 @@ public final class VoiceMuteCommand implements McCommand {
                 duration,
                 durationUnit,
                 reason,
-                false
+                !voiceServer.getConfig().notifications().muted()
         );
     }
 

--- a/server/common/src/main/java/su/plo/voice/server/command/VoiceUnmuteCommand.java
+++ b/server/common/src/main/java/su/plo/voice/server/command/VoiceUnmuteCommand.java
@@ -42,7 +42,7 @@ public final class VoiceUnmuteCommand implements McCommand {
 
         MuteManager muteManager = voiceServer.getMuteManager();
 
-        if (!muteManager.unmute(player.getId(), false).isPresent()) {
+        if (!muteManager.unmute(player.getId(), !voiceServer.getConfig().notifications().unmuted()).isPresent()) {
             source.sendMessage(
                     McTextComponent.translatable("pv.command.unmute.not_muted", player.getName())
             );

--- a/server/common/src/main/java/su/plo/voice/server/config/VoiceServerConfig.java
+++ b/server/common/src/main/java/su/plo/voice/server/config/VoiceServerConfig.java
@@ -63,6 +63,22 @@ public final class VoiceServerConfig implements ServerConfig {
     @ConfigField
     private Voice voice = new Voice();
 
+    @ConfigField
+    private Notifications notifications = new Notifications();
+
+    @Config
+    @Data
+    @Accessors(fluent = true)
+    @EqualsAndHashCode
+    public static class Notifications implements ServerConfig.Notifications {
+
+        @ConfigField(comment = "Notify a player when their voice chat is muted (\"You've been muted ...\" message)")
+        private boolean muted = true;
+
+        @ConfigField(comment = "Notify a player when their voice chat is unmuted (\"You've been unmuted\" message)")
+        private boolean unmuted = true;
+    }
+
     @Config
     @Data
     @Accessors(fluent = true)

--- a/server/common/src/main/java/su/plo/voice/server/mute/VoiceMuteManager.java
+++ b/server/common/src/main/java/su/plo/voice/server/mute/VoiceMuteManager.java
@@ -73,7 +73,7 @@ public final class VoiceMuteManager implements MuteManager {
             }
         }
 
-        ServerMuteInfo muteInfo = new ServerMuteInfo(playerId, mutedById, System.currentTimeMillis(), duration, reason);
+        ServerMuteInfo muteInfo = new ServerMuteInfo(playerId, mutedById, System.currentTimeMillis(), duration, reason, silent);
 
         muteStorage.putPlayerMute(player.getInstance().getUuid(), muteInfo);
 
@@ -138,7 +138,9 @@ public final class VoiceMuteManager implements MuteManager {
     private void tick() {
         muteStorage.getMutedPlayers().forEach((muteInfo) -> {
             if (!isMuteValid(muteInfo)) {
-                unmute(muteInfo.getPlayerUUID(), false);
+                boolean silent = Boolean.TRUE.equals(muteInfo.getSilent())
+                        || !voiceServer.getConfig().notifications().unmuted();
+                unmute(muteInfo.getPlayerUUID(), silent);
             }
         });
     }


### PR DESCRIPTION
Adds a new config block in server's config:
```toml
[notifications]
# Notify a player when their voice chat is muted ("You've been muted ..." message)
muted = true
# Notify a player when their voice chat is unmuted ("You've been unmuted" message)
unmuted = true
```

## [Download Build](https://artifacts.plasmoverse.com/projects/plasmo-voice/branches/pr-522)