### PR TITLE
Update Gradle and Actions

### DIFF
--- a/.github/workflows/publish-pr-snapshot.yml
+++ b/.github/workflows/publish-pr-snapshot.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v5.7.0
       with:
         distribution: temurin
         java-version: |
@@ -29,7 +29,7 @@ jobs:
           21
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6.3.0
       with:
         cache-read-only: false
 

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -14,9 +14,9 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7.0.0
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v5.7.0
       with:
         distribution: temurin
         java-version: |
@@ -26,7 +26,7 @@ jobs:
           21
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6.3.0
       with:
         cache-read-only: false
 
@@ -102,7 +102,7 @@ jobs:
 
     - name: Deploy to GitHub Pages
       if: ${{ steps.release-check.outputs.released != 'true' }}
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build/dokka/html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,9 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7.0.1
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v5.7.0
       with:
         distribution: temurin
         java-version: |
@@ -52,7 +52,7 @@ jobs:
           21
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6.3.0
       with:
         cache-read-only: false
 
@@ -90,7 +90,7 @@ jobs:
       run: ./gradlew publish
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: build-libs
         path: build/libs/
@@ -105,9 +105,9 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7.0.0
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.1
       with:
         name: build-libs
         path: build/libs/
@@ -185,9 +185,9 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7.0.0
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.1
       with:
         name: build-libs
         path: build/libs/
@@ -216,9 +216,9 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7.0.0
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.1
       with:
         name: build-libs
         path: build/libs/
@@ -254,9 +254,9 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7.0.0
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v5.7.0
       with:
         distribution: temurin
         java-version: |
@@ -266,7 +266,7 @@ jobs:
           21
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6.3.0
       with:
         cache-read-only: false
 
@@ -298,7 +298,7 @@ jobs:
       run: ./gradlew dokkaGeneratePublicationHtml
 
     - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build/dokka/html

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -72,7 +72,7 @@ if (isMainProject) {
     }
 }
 
-val shadowCommon by configurations.creating
+val shadowCommon = configurations.create("shadowCommon")
 
 val mcVersionsRange = project.property("mod.minecraft_versions") as String
 val forgeVersionRange = project.findProperty("mod.forge_version") as String? ?: ""

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ group=su.plo.voice
 version=2.1.14
 
 # Gradle args
-org.gradle.jvmargs=-Xmx2G -Dkotlin.daemon.jvm.options=-Xmx1G
+org.gradle.jvmargs=-Xmx2G -Dkotlin.daemon.jvm.options=-Xmx1G --enable-native-access=ALL-UNNAMED
 org.gradle.workers.max=2
 kotlin.stdlib.default.dependency=false
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bumped Gradle to 9.7.0 and bumped the GitHub Actions to their actual latest pinned versions instead of floating and old major tags.

Of course, CI needs to actually run green here before merging.