### PR TITLE
Accelerate Gradle build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,9 @@ group=su.plo.voice
 version=2.1.14
 
 # Gradle args
-org.gradle.jvmargs=-Xmx2G -Dkotlin.daemon.jvm.options=-Xmx1G --enable-native-access=ALL-UNNAMED
-org.gradle.workers.max=2
+org.gradle.jvmargs=-Xmx4G -Dkotlin.daemon.jvm.options=-Xmx1G --enable-native-access=ALL-UNNAMED
+org.gradle.workers.max=4
+org.gradle.parallel=true
 kotlin.stdlib.default.dependency=false
 
 # default 3


### PR DESCRIPTION
`-Xmx2G` with `workers.max=2` on a project with such amount of client versions is a pure joke.

Bumped Gradle daemon heap from 2G to 4G, `workers.max` from 2 to 4, and enabled `org.gradle.parallel=true`.