### PR TITLE
feat(proxy): create proxy<->backend socket per client connection

### DIFF
--- a/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyPacketHandler.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyPacketHandler.java
@@ -1,25 +1,23 @@
 package su.plo.voice.proxy.socket;
 
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramChannel;
-import io.netty.channel.socket.DatagramPacket;
 import lombok.AllArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import su.plo.slib.api.proxy.connection.McProxyServerConnection;
 import su.plo.voice.BaseVoice;
 import su.plo.voice.api.proxy.player.VoiceProxyPlayer;
 import su.plo.voice.api.proxy.server.RemoteServer;
 import su.plo.voice.api.proxy.socket.UdpProxyConnection;
 import su.plo.voice.proto.packets.udp.PacketUdp;
-import su.plo.voice.proto.packets.udp.PacketUdpCodec;
 import su.plo.voice.proto.packets.udp.bothbound.PingPacket;
 import su.plo.voice.proxy.BaseVoiceProxy;
 import su.plo.voice.proxy.connection.CancelForwardingException;
 import su.plo.voice.proxy.server.VoiceRemoteServer;
 import su.plo.voice.socket.NettyPacketUdp;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Objects;
 import java.util.Optional;
@@ -29,6 +27,8 @@ import java.util.UUID;
 public final class NettyPacketHandler extends SimpleChannelInboundHandler<NettyPacketUdp> {
 
     private final BaseVoiceProxy voiceProxy;
+    private final EventLoopGroup loopGroup;
+    private final Class<? extends DatagramChannel> channelClass;
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, NettyPacketUdp nettyPacket) throws Exception {
@@ -36,10 +36,13 @@ public final class NettyPacketHandler extends SimpleChannelInboundHandler<NettyP
 
         UUID secret = packet.getSecret();
 
-        if (voiceProxy.getUdpConnectionManager().getConnectionByAnySecret(secret)
-                .map(connection -> sendPacket(ctx, nettyPacket, connection))
-                .orElse(false)
-        ) return;
+        Optional<UdpProxyConnection> existingConnection = voiceProxy.getUdpConnectionManager().getConnectionBySecret(secret);
+        if (existingConnection.isPresent()) {
+            if (existingConnection.get() instanceof NettyUdpProxyConnection) {
+                forwardPacket(nettyPacket, (NettyUdpProxyConnection) existingConnection.get());
+            }
+            return;
+        }
 
         BaseVoice.DEBUG_LOGGER.log("Connection with secret {}", secret);
 
@@ -84,10 +87,11 @@ public final class NettyPacketHandler extends SimpleChannelInboundHandler<NettyP
                 voiceProxy,
                 (DatagramChannel) ctx.channel(),
                 player.get(),
-                secret
+                secret,
+                loopGroup,
+                channelClass
         );
         connection.setRemoteSecret(remoteSecret.get());
-        connection.setRemoteServer(remoteServer.get());
         connection.setRemoteAddress(nettyPacket.getDatagramPacket().sender());
         if (packet.getPacketUntyped() instanceof PingPacket) {
             PingPacket pingPacket = (PingPacket) packet.getPacketUntyped();
@@ -95,62 +99,26 @@ public final class NettyPacketHandler extends SimpleChannelInboundHandler<NettyP
                 connection.setConnectionAddress(InetSocketAddress.createUnresolved(pingPacket.getServerIp(), pingPacket.getServerPort()));
             }
         }
+        connection.setRemoteServer(remoteServer.get());
         voiceProxy.getUdpConnectionManager().addConnection(connection);
 
-        sendPacket(ctx, nettyPacket, connection);
+        forwardPacket(nettyPacket, connection);
     }
 
-    private boolean sendPacket(ChannelHandlerContext ctx, NettyPacketUdp nettyPacket, UdpProxyConnection connection) {
-        if (!connection.getRemoteServer().isPresent()) return false;
-
-        RemoteServer remoteServer = connection.getRemoteServer().get();
-
+    private void forwardPacket(@NotNull NettyPacketUdp nettyPacket, @NotNull NettyUdpProxyConnection connection) {
         InetSocketAddress sender = nettyPacket.getDatagramPacket().sender();
-        InetSocketAddress receiver;
-        UUID receiverSecret;
-
-        if (connection.getSecret().equals(nettyPacket.getPacketUdp().getSecret())) {
-            receiver = remoteServer.getAddress();
-            receiverSecret = connection.getRemoteSecret();
-
-            if (!Objects.equals(connection.getRemoteAddress(), sender)) {
-                connection.setRemoteAddress(nettyPacket.getDatagramPacket().sender());
-            }
-
-            // handle packet
-            try {
-                connection.handlePacket(nettyPacket.getPacketUdp().getPacket());
-            } catch (CancelForwardingException ignored) {
-                return true;
-            } catch (ClassCastException e) {
-                BaseVoice.DEBUG_LOGGER.log(
-                        "Packet {} was received from remote server: {}; connection remote server: {}",
-                        nettyPacket.getPacketUdp(),
-                        sender,
-                        remoteServer.getAddress()
-                );
-
-                if (BaseVoice.DEBUG_LOGGER.enabled()) {
-                    e.printStackTrace();
-                }
-            } catch (Throwable e) {
-                BaseVoice.DEBUG_LOGGER.log("Failed to decode packet", e);
-            }
-        } else {
-            receiver = connection.getRemoteAddress();
-            receiverSecret = connection.getSecret();
-
-            if (!connection.isConnected() || connection.getPlayer().getInstance().getServer() == null) return true;
+        if (!Objects.equals(connection.getRemoteAddress(), sender)) {
+            connection.setRemoteAddress(sender);
         }
 
-        // rewrite to backend server
-        ctx.channel().writeAndFlush(new DatagramPacket(
-                Unpooled.wrappedBuffer(PacketUdpCodec.replaceSecret(
-                        nettyPacket.getPacketData(),
-                        receiverSecret
-                )),
-                receiver
-        ));
-        return true;
+        try {
+            connection.handlePacket(nettyPacket.getPacketUdp().getPacket());
+        } catch (CancelForwardingException ignored) {
+            return;
+        } catch (Throwable e) {
+            BaseVoice.DEBUG_LOGGER.log("Failed to decode packet", e);
+        }
+
+        connection.sendPacketToRemoteServer(nettyPacket);
     }
 }

--- a/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyConnection.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyConnection.java
@@ -1,29 +1,44 @@
 package su.plo.voice.proxy.socket;
 
+import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import su.plo.voice.BaseVoice;
 import su.plo.voice.api.proxy.PlasmoVoiceProxy;
 import su.plo.voice.api.proxy.player.VoiceProxyPlayer;
 import su.plo.voice.api.proxy.server.RemoteServer;
 import su.plo.voice.api.proxy.socket.UdpProxyConnection;
 import su.plo.voice.api.server.event.audio.source.PlayerSpeakEvent;
 import su.plo.voice.proto.packets.Packet;
+import su.plo.voice.proto.packets.PacketDirection;
 import su.plo.voice.proto.packets.udp.PacketUdpCodec;
 import su.plo.voice.proto.packets.udp.bothbound.CustomPacket;
 import su.plo.voice.proto.packets.udp.bothbound.PingPacket;
 import su.plo.voice.proto.packets.udp.serverbound.PlayerAudioPacket;
 import su.plo.voice.proto.packets.udp.serverbound.ServerPacketUdpHandler;
 import su.plo.voice.proxy.connection.CancelForwardingException;
+import su.plo.voice.socket.NettyExceptionHandler;
+import su.plo.voice.socket.NettyPacketUdp;
+import su.plo.voice.socket.NettyPacketUdpDecoder;
 
 import java.net.InetSocketAddress;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 @RequiredArgsConstructor
 public final class NettyUdpProxyConnection implements UdpProxyConnection, ServerPacketUdpHandler {
@@ -36,19 +51,34 @@ public final class NettyUdpProxyConnection implements UdpProxyConnection, Server
     @Getter
     private final UUID secret;
 
+    private final EventLoopGroup loopGroup;
+    private final Class<? extends DatagramChannel> channelClass;
+
     @Getter @Setter
-    private UUID remoteSecret;
+    private volatile UUID remoteSecret;
     @Getter @Setter
-    private InetSocketAddress connectionAddress;
+    private volatile InetSocketAddress connectionAddress;
     @Getter @Setter
-    private InetSocketAddress remoteAddress;
-    @Setter
+    private volatile InetSocketAddress remoteAddress;
+
     private RemoteServer remoteServer;
-    private boolean connected = true;
+    private final AtomicReference<ChannelFuture> remoteChannelFuture = new AtomicReference<>();
+    private volatile boolean connected = true;
 
     @Override
     public Optional<RemoteServer> getRemoteServer() {
         return Optional.ofNullable(remoteServer);
+    }
+
+    @Override
+    public void setRemoteServer(@NotNull RemoteServer remoteServer) {
+        RemoteServer previousServer = this.remoteServer;
+        this.remoteServer = remoteServer;
+
+        InetSocketAddress address = remoteServer.getAddress(true);
+        if (previousServer != null && address.equals(previousServer.getAddress())) return;
+
+        connectToRemoteServer(address);
     }
 
     @Override
@@ -71,6 +101,7 @@ public final class NettyUdpProxyConnection implements UdpProxyConnection, Server
     @Override
     public void disconnect() {
         this.connected = false;
+        closeChannel(remoteChannelFuture.getAndSet(null));
     }
 
     @Override
@@ -90,6 +121,73 @@ public final class NettyUdpProxyConnection implements UdpProxyConnection, Server
     public void handle(@NotNull PlayerAudioPacket packet) {
         if (!voiceProxy.getEventBus().fire(new PlayerSpeakEvent(player, packet))) {
             throw new CancelForwardingException();
+        }
+    }
+
+    void sendPacketToRemoteServer(@NotNull NettyPacketUdp nettyPacket) {
+        ChannelFuture channelFuture = remoteChannelFuture.get();
+        if (channelFuture == null || !connected || !channelFuture.isSuccess()) return;
+
+        UUID remoteSecret = this.remoteSecret;
+        if (remoteSecret == null) return;
+
+        ByteBuf buf = Unpooled.wrappedBuffer(
+                PacketUdpCodec.replaceSecret(nettyPacket.getPacketData(), remoteSecret)
+        );
+
+        channelFuture.channel().writeAndFlush(buf);
+    }
+
+    private void connectToRemoteServer(@NotNull InetSocketAddress address) {
+        if (!connected) return;
+
+        BaseVoice.DEBUG_LOGGER.log(
+                "Connecting to remote server {} for {}",
+                address, player.getInstance().getName()
+        );
+
+        Bootstrap bootstrap = new Bootstrap();
+        bootstrap
+                .group(loopGroup)
+                .channel(channelClass);
+
+        bootstrap.handler(new ChannelInitializer<DatagramChannel>() {
+            @Override
+            protected void initChannel(@NotNull DatagramChannel ch) {
+                ChannelPipeline pipeline = ch.pipeline();
+
+                pipeline.addLast("decoder", new NettyPacketUdpDecoder(PacketDirection.CLIENT));
+                pipeline.addLast("handler", new RemoteServerPacketHandler());
+                pipeline.addLast("exception_handler", new NettyExceptionHandler());
+            }
+        });
+
+        ChannelFuture channelFuture = bootstrap.connect(address);
+        channelFuture.addListener((ChannelFutureListener) future -> {
+            if (future.isSuccess()) return;
+            BaseVoice.DEBUG_LOGGER.log("Failed to connect to remote server {}", address, future.cause());
+        });
+
+        closeChannel(remoteChannelFuture.getAndSet(channelFuture));
+
+        if (!connected && remoteChannelFuture.compareAndSet(channelFuture, null)) {
+            channelFuture.channel().close();
+        }
+    }
+
+    private void closeChannel(@Nullable ChannelFuture channelFuture) {
+        if (channelFuture != null) channelFuture.channel().close();
+    }
+
+    private final class RemoteServerPacketHandler extends SimpleChannelInboundHandler<NettyPacketUdp> {
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, NettyPacketUdp nettyPacket) {
+            if (!connected || player.getInstance().getServer() == null) return;
+
+            channel.writeAndFlush(new DatagramPacket(
+                    Unpooled.wrappedBuffer(PacketUdpCodec.replaceSecret(nettyPacket.getPacketData(), secret)),
+                    remoteAddress
+            ));
         }
     }
 }

--- a/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyServer.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyServer.java
@@ -3,6 +3,7 @@ package su.plo.voice.proxy.socket;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.Epoll;
@@ -33,6 +34,7 @@ public final class NettyUdpProxyServer implements UdpProxyServer {
     private final BaseVoiceProxy voiceProxy;
 
     private final EventLoopGroup loopGroup;
+    private final Class<? extends DatagramChannel> channelClass;
 
     private DatagramChannel channel;
     private InetSocketAddress socketAddress;
@@ -45,15 +47,13 @@ public final class NettyUdpProxyServer implements UdpProxyServer {
         this.loopGroup = useEpoll
                 ? new EpollEventLoopGroup(0, factory)
                 : new NioEventLoopGroup(0, factory);
+        this.channelClass = useEpoll
+                ? EpollDatagramChannel.class
+                : NioDatagramChannel.class;
     }
 
     @Override
     public void start(String ip, int port) {
-
-        Class<? extends DatagramChannel> channelClass = useEpoll
-                ? EpollDatagramChannel.class
-                : NioDatagramChannel.class;
-
         Bootstrap bootstrap = new Bootstrap();
         bootstrap
                 .group(loopGroup)
@@ -64,8 +64,8 @@ public final class NettyUdpProxyServer implements UdpProxyServer {
             protected void initChannel(@NotNull DatagramChannel ch) throws Exception {
                 ChannelPipeline pipeline = ch.pipeline();
 
-                pipeline.addLast("decoder", new NettyPacketUdpDecoder(PacketDirection.ANY));
-                pipeline.addLast("handler", new NettyPacketHandler(voiceProxy));
+                pipeline.addLast("decoder", new NettyPacketUdpDecoder(PacketDirection.SERVER));
+                pipeline.addLast("handler", new NettyPacketHandler(voiceProxy, loopGroup, channelClass));
                 pipeline.addLast("exception_handler", new NettyExceptionHandler());
             }
         });
@@ -87,6 +87,7 @@ public final class NettyUdpProxyServer implements UdpProxyServer {
 
     @Override
     public void stop() {
+        voiceProxy.getUdpConnectionManager().clearConnections();
         if (channel != null) channel.close();
         loopGroup.shutdownGracefully();
         BaseVoice.LOGGER.info("UDP proxy server is stopped");


### PR DESCRIPTION
Right now proxy uses one public socket to accept both client packets and proxy<->backend packets.
It's impossible to reasonably scale and puts one thread/socket to x2 workload, which becomes a bottleneck way before backend does (e.g. backend can handle 150k pps just fine, but just because it stands behind a proxy, proxy will throttle at 50k pps and drop packets).

This is also a hard-requirement for proxy-side reuseport from #503, because reuseport uses hash of `peer_addr:port<->local_addr:port` to assign sockets, causing all backend->proxy packets to be assigned to one socket, making reuseport basically useless.