### PR TITLE
feat: reuseport

### DIFF
--- a/api/proxy/src/main/java/su/plo/voice/api/proxy/config/ProxyConfig.java
+++ b/api/proxy/src/main/java/su/plo/voice/api/proxy/config/ProxyConfig.java
@@ -33,6 +33,6 @@ public interface ProxyConfig {
     interface ReusePort {
         boolean enabled();
 
-        int channels();
+        int sockets();
     }
 }

--- a/api/proxy/src/main/java/su/plo/voice/api/proxy/config/ProxyConfig.java
+++ b/api/proxy/src/main/java/su/plo/voice/api/proxy/config/ProxyConfig.java
@@ -21,10 +21,18 @@ public interface ProxyConfig {
 
     @NotNull Host host();
 
+    @NotNull ReusePort reusePort();
+
     interface Host {
 
         @NotNull String ip();
 
         int port();
+    }
+
+    interface ReusePort {
+        boolean enabled();
+
+        int channels();
     }
 }

--- a/api/server/src/main/java/su/plo/voice/api/server/config/ServerConfig.java
+++ b/api/server/src/main/java/su/plo/voice/api/server/config/ServerConfig.java
@@ -90,7 +90,7 @@ public interface ServerConfig {
         interface ReusePort {
             boolean enabled();
 
-            int channels();
+            int sockets();
         }
 
         interface PlayerIcon {

--- a/api/server/src/main/java/su/plo/voice/api/server/config/ServerConfig.java
+++ b/api/server/src/main/java/su/plo/voice/api/server/config/ServerConfig.java
@@ -77,6 +77,8 @@ public interface ServerConfig {
 
         @NotNull String clientModMinVersion();
 
+        @NotNull ReusePort reusePort();
+
         @NotNull Proximity proximity();
 
         @NotNull Opus opus();
@@ -84,6 +86,12 @@ public interface ServerConfig {
         @NotNull PlayerIcon playerIcon();
 
         @NotNull Weights weights();
+
+        interface ReusePort {
+            boolean enabled();
+
+            int channels();
+        }
 
         interface PlayerIcon {
             Collection<PlayerIconVisibility> visibility();

--- a/common/src/main/kotlin/su/plo/voice/util/SystemProperty.kt
+++ b/common/src/main/kotlin/su/plo/voice/util/SystemProperty.kt
@@ -1,0 +1,4 @@
+package su.plo.voice.util
+
+fun getIntSystemProperty(name: String, default: Int): Int =
+    System.getProperty(name)?.toInt() ?: default

--- a/proxy/common/src/main/java/su/plo/voice/proxy/BaseVoiceProxy.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/BaseVoiceProxy.java
@@ -149,7 +149,8 @@ public abstract class BaseVoiceProxy extends BaseVoice implements PlasmoVoicePro
             TOML.save(VoiceProxyConfig.class, config, configFile);
 
             if (oldConfig != null) {
-                restartUdpServer = !config.host().equals(oldConfig.host());
+                restartUdpServer = !config.host().equals(oldConfig.host()) ||
+                        !config.reusePort().equals(oldConfig.reusePort());
             }
 
             ServerTranslator serverTranslator = getMinecraftServer().getServerTranslator();

--- a/proxy/common/src/main/java/su/plo/voice/proxy/config/VoiceProxyConfig.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/config/VoiceProxyConfig.java
@@ -69,11 +69,36 @@ public final class VoiceProxyConfig implements ProxyConfig {
     @ConfigField
     private VoiceHost host = new VoiceHost();
 
+    @ConfigField
+    private ReusePort reusePort = new ReusePort();
+
     @ConfigField(
             comment = "Override voice server addresses for specific backend servers\nBy default, uses the same address as the Minecraft backend server (from Velocity/BungeeCord config)",
             nullComment = "[servers]\nfarmworld = \"127.0.0.1:25565\"\noverworld = \"127.0.0.1:25566\""
     )
     private Servers servers = new Servers();
+
+    @Config
+    @Data
+    @Accessors(fluent = true)
+    public static class ReusePort implements ProxyConfig.ReusePort {
+        @ConfigField(
+                comment =
+                        "Enables SO_REUSEPORT\n" +
+                                "Instead of using one single thread for all incoming connections,\n" +
+                                "multiple sockets will be bound on the same port\n" +
+                                "and distribute connections between multiple worker threads\n" +
+                                "Requires Linux or macOS"
+        )
+        private boolean enabled = false;
+
+        @ConfigField(
+                comment =
+                        "Amount of sockets/threads that'll be open with SO_REUSEPORT enabled\n\n" +
+                                "0 means auto and will be derived from \"io.netty.eventLoopThreads\""
+        )
+        private int channels = 0;
+    }
 
     @NoArgsConstructor
     public static class MtuSizeValidator implements Predicate<Object> {

--- a/proxy/common/src/main/java/su/plo/voice/proxy/config/VoiceProxyConfig.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/config/VoiceProxyConfig.java
@@ -85,19 +85,19 @@ public final class VoiceProxyConfig implements ProxyConfig {
         @ConfigField(
                 comment =
                         "Enables SO_REUSEPORT\n" +
-                                "Instead of using one single thread for all incoming connections,\n" +
-                                "multiple sockets will be bound on the same port\n" +
-                                "and distribute connections between multiple worker threads\n" +
-                                "Requires Linux or macOS"
+                        "Instead of using one single thread for all incoming connections,\n" +
+                        "multiple sockets will be bound on the same port\n" +
+                        "and distribute connections between multiple worker threads\n" +
+                        "Requires Linux or macOS"
         )
         private boolean enabled = false;
 
         @ConfigField(
                 comment =
-                        "Amount of sockets/threads that'll be open with SO_REUSEPORT enabled\n\n" +
-                                "0 means auto and will be derived from \"io.netty.eventLoopThreads\""
+                        "Amount of sockets that'll be open with SO_REUSEPORT enabled\n\n" +
+                        "When set to 0, amount of channel will match amount of available CPU cores * 2"
         )
-        private int channels = 0;
+        private int sockets = 4;
     }
 
     @NoArgsConstructor

--- a/proxy/common/src/main/java/su/plo/voice/proxy/config/VoiceProxyConfig.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/config/VoiceProxyConfig.java
@@ -94,7 +94,7 @@ public final class VoiceProxyConfig implements ProxyConfig {
 
         @ConfigField(
                 comment =
-                        "Amount of sockets that'll be open with SO_REUSEPORT enabled\n\n" +
+                        "Amount of sockets that'll be open with SO_REUSEPORT enabled\n" +
                         "When set to 0, amount of channel will match amount of available CPU cores * 2"
         )
         private int sockets = 4;

--- a/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyPacketHandler.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyPacketHandler.java
@@ -29,6 +29,7 @@ public final class NettyPacketHandler extends SimpleChannelInboundHandler<NettyP
     private final BaseVoiceProxy voiceProxy;
     private final EventLoopGroup loopGroup;
     private final Class<? extends DatagramChannel> channelClass;
+    private final boolean pinConnectionToChannelLoop;
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, NettyPacketUdp nettyPacket) throws Exception {
@@ -88,7 +89,7 @@ public final class NettyPacketHandler extends SimpleChannelInboundHandler<NettyP
                 (DatagramChannel) ctx.channel(),
                 player.get(),
                 secret,
-                loopGroup,
+                pinConnectionToChannelLoop ? ctx.channel().eventLoop() : loopGroup,
                 channelClass
         );
         connection.setRemoteSecret(remoteSecret.get());

--- a/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyConnection.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyConnection.java
@@ -23,7 +23,6 @@ import su.plo.voice.api.proxy.server.RemoteServer;
 import su.plo.voice.api.proxy.socket.UdpProxyConnection;
 import su.plo.voice.api.server.event.audio.source.PlayerSpeakEvent;
 import su.plo.voice.proto.packets.Packet;
-import su.plo.voice.proto.packets.PacketDirection;
 import su.plo.voice.proto.packets.udp.PacketUdpCodec;
 import su.plo.voice.proto.packets.udp.bothbound.CustomPacket;
 import su.plo.voice.proto.packets.udp.bothbound.PingPacket;
@@ -33,7 +32,6 @@ import su.plo.voice.proxy.connection.CancelForwardingException;
 import su.plo.voice.socket.ByteBufDataOutput;
 import su.plo.voice.socket.NettyExceptionHandler;
 import su.plo.voice.socket.NettyPacketUdp;
-import su.plo.voice.socket.NettyPacketUdpDecoder;
 
 import java.net.InetSocketAddress;
 import java.util.Optional;

--- a/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyServer.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyServer.java
@@ -26,12 +26,21 @@ import su.plo.voice.proto.packets.PacketDirection;
 import su.plo.voice.proxy.BaseVoiceProxy;
 import su.plo.voice.socket.NettyExceptionHandler;
 import su.plo.voice.socket.NettyPacketUdpDecoder;
+import su.plo.voice.util.SystemPropertyKt;
 
 import java.net.InetSocketAddress;
 import java.util.Optional;
 import java.util.concurrent.ThreadFactory;
 
 public final class NettyUdpProxyServer implements UdpProxyServer {
+
+    private static final int DEFAULT_THREADS = Math.max(
+            1,
+            SystemPropertyKt.getIntSystemProperty(
+                    "plasmovoice.udp_threads",
+                    Runtime.getRuntime().availableProcessors() * 2
+            )
+    );
 
     private final boolean useEpoll = System.getProperty("plasmovoice.use_epoll", "true").equals("true") &&
             Epoll.isAvailable();
@@ -50,8 +59,8 @@ public final class NettyUdpProxyServer implements UdpProxyServer {
         ThreadFactory factory = new DefaultThreadFactory("plasmo-voice-udp", Thread.MAX_PRIORITY);
 
         this.loopGroup = useEpoll
-                ? new EpollEventLoopGroup(0, factory)
-                : new NioEventLoopGroup(0, factory);
+                ? new EpollEventLoopGroup(DEFAULT_THREADS, factory)
+                : new NioEventLoopGroup(DEFAULT_THREADS, factory);
         this.channelClass = useEpoll
                 ? EpollDatagramChannel.class
                 : NioDatagramChannel.class;

--- a/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyServer.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyServer.java
@@ -65,18 +65,6 @@ public final class NettyUdpProxyServer implements UdpProxyServer {
                 .group(loopGroup)
                 .channel(channelClass);
 
-        bootstrap.handler(new ChannelInitializer<DatagramChannel>() {
-            @Override
-            protected void initChannel(@NotNull DatagramChannel ch) throws Exception {
-                ChannelPipeline pipeline = ch.pipeline();
-
-                pipeline.addLast("flush_consolidation", new FlushConsolidationHandler(256, true));
-                pipeline.addLast("decoder", new NettyPacketUdpDecoder(PacketDirection.SERVER));
-                pipeline.addLast("handler", new NettyPacketHandler(voiceProxy, loopGroup, channelClass));
-                pipeline.addLast("exception_handler", new NettyExceptionHandler());
-            }
-        });
-
         boolean reusePortEnabled = false;
         if (useEpoll && voiceProxy.getConfig().reusePort().enabled()) {
             try {
@@ -87,15 +75,29 @@ public final class NettyUdpProxyServer implements UdpProxyServer {
             }
         }
 
+        int channelCount = reusePortEnabled
+                ? voiceProxy.getConfig().reusePort().channels()
+                : 1;
+        if (channelCount <= 0) {
+            channelCount = ((MultithreadEventLoopGroup) loopGroup).executorCount();
+        }
+
+        boolean pinConnectionToChannel = reusePortEnabled && channelCount > 1;
+
+        bootstrap.handler(new ChannelInitializer<DatagramChannel>() {
+            @Override
+            protected void initChannel(@NotNull DatagramChannel ch) {
+                ChannelPipeline pipeline = ch.pipeline();
+
+                pipeline.addLast("flush_consolidation", new FlushConsolidationHandler(256, true));
+                pipeline.addLast("decoder", new NettyPacketUdpDecoder(PacketDirection.SERVER));
+                pipeline.addLast("handler", new NettyPacketHandler(voiceProxy, loopGroup, channelClass, pinConnectionToChannel));
+                pipeline.addLast("exception_handler", new NettyExceptionHandler());
+            }
+        });
+
         BaseVoice.LOGGER.info("UDP proxy server is starting on {}:{}", ip, port);
         try {
-            int channelCount = reusePortEnabled
-                    ? voiceProxy.getConfig().reusePort().channels()
-                    : 1;
-            if (channelCount <= 0) {
-                channelCount = ((MultithreadEventLoopGroup) loopGroup).executorCount();
-            }
-
             for (int i = 0; i < channelCount; i++) {
                 ChannelFuture channelFuture = bootstrap.bind(ip, port).sync();
                 Channel channel = channelFuture.channel();

--- a/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyServer.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyServer.java
@@ -1,18 +1,24 @@
 package su.plo.voice.proxy.socket;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.channel.unix.UnixChannelOption;
 import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.GlobalEventExecutor;
 import org.jetbrains.annotations.NotNull;
 import su.plo.voice.BaseVoice;
 import su.plo.voice.api.proxy.event.socket.UdpProxyServerStoppedEvent;
@@ -36,7 +42,7 @@ public final class NettyUdpProxyServer implements UdpProxyServer {
     private final EventLoopGroup loopGroup;
     private final Class<? extends DatagramChannel> channelClass;
 
-    private DatagramChannel channel;
+    private final ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
     private InetSocketAddress socketAddress;
 
     public NettyUdpProxyServer(@NotNull BaseVoiceProxy voiceServer) {
@@ -71,25 +77,55 @@ public final class NettyUdpProxyServer implements UdpProxyServer {
             }
         });
 
+        boolean reusePortEnabled = false;
+        if (useEpoll && voiceProxy.getConfig().reusePort().enabled()) {
+            try {
+                bootstrap.option(UnixChannelOption.SO_REUSEPORT, true);
+                reusePortEnabled = true;
+            } catch (Exception e) {
+                BaseVoice.LOGGER.warn("SO_REUSEPORT not supported on this platform, falling back to single channel");
+            }
+        }
+
         BaseVoice.LOGGER.info("UDP proxy server is starting on {}:{}", ip, port);
         try {
-            ChannelFuture channelFuture = bootstrap.bind(ip, port).sync();
-            this.channel = (DatagramChannel) channelFuture.channel();
-            this.socketAddress = channel.localAddress();
+            int channelCount = reusePortEnabled
+                    ? voiceProxy.getConfig().reusePort().channels()
+                    : 1;
+            if (channelCount <= 0) {
+                channelCount = ((MultithreadEventLoopGroup) loopGroup).executorCount();
+            }
+
+            for (int i = 0; i < channelCount; i++) {
+                ChannelFuture channelFuture = bootstrap.bind(ip, port).sync();
+                Channel channel = channelFuture.channel();
+                channelGroup.add(channel);
+
+                this.socketAddress = (InetSocketAddress) channel.localAddress();
+            }
+
+            if (reusePortEnabled && channelCount > 1) {
+                BaseVoice.LOGGER.info(
+                        "Bound {} {} UDP proxy instances with SO_REUSEPORT on {}",
+                        channelCount,
+                        channelClass.getSimpleName(),
+                        socketAddress
+                );
+            } else {
+                BaseVoice.LOGGER.info("{} UDP proxy is started on {}", channelClass.getSimpleName(), socketAddress);
+            }
         } catch (InterruptedException e) {
             stop();
-            return;
         } catch (Exception e) {
             stop();
             throw e;
         }
-        BaseVoice.LOGGER.info("{} UDP proxy server is started on {}", channelClass.getSimpleName(), socketAddress);
     }
 
     @Override
     public void stop() {
         voiceProxy.getUdpConnectionManager().clearConnections();
-        if (channel != null) channel.close();
+        channelGroup.close();
         loopGroup.shutdownGracefully();
         BaseVoice.LOGGER.info("UDP proxy server is stopped");
 

--- a/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyServer.java
+++ b/proxy/common/src/main/java/su/plo/voice/proxy/socket/NettyUdpProxyServer.java
@@ -6,7 +6,6 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
@@ -75,14 +74,14 @@ public final class NettyUdpProxyServer implements UdpProxyServer {
             }
         }
 
-        int channelCount = reusePortEnabled
-                ? voiceProxy.getConfig().reusePort().channels()
+        int socketsAmount = reusePortEnabled
+                ? voiceProxy.getConfig().reusePort().sockets()
                 : 1;
-        if (channelCount <= 0) {
-            channelCount = ((MultithreadEventLoopGroup) loopGroup).executorCount();
+        if (socketsAmount <= 0) {
+            socketsAmount = Runtime.getRuntime().availableProcessors() * 2;
         }
 
-        boolean pinConnectionToChannel = reusePortEnabled && channelCount > 1;
+        boolean pinConnectionToChannel = reusePortEnabled && socketsAmount > 1;
 
         bootstrap.handler(new ChannelInitializer<DatagramChannel>() {
             @Override
@@ -98,7 +97,7 @@ public final class NettyUdpProxyServer implements UdpProxyServer {
 
         BaseVoice.LOGGER.info("UDP proxy server is starting on {}:{}", ip, port);
         try {
-            for (int i = 0; i < channelCount; i++) {
+            for (int i = 0; i < socketsAmount; i++) {
                 ChannelFuture channelFuture = bootstrap.bind(ip, port).sync();
                 Channel channel = channelFuture.channel();
                 channelGroup.add(channel);
@@ -106,10 +105,10 @@ public final class NettyUdpProxyServer implements UdpProxyServer {
                 this.socketAddress = (InetSocketAddress) channel.localAddress();
             }
 
-            if (reusePortEnabled && channelCount > 1) {
+            if (reusePortEnabled && socketsAmount > 1) {
                 BaseVoice.LOGGER.info(
                         "Bound {} {} UDP proxy instances with SO_REUSEPORT on {}",
-                        channelCount,
+                        socketsAmount,
                         channelClass.getSimpleName(),
                         socketAddress
                 );

--- a/server/common/src/main/java/su/plo/voice/server/BaseVoiceServer.java
+++ b/server/common/src/main/java/su/plo/voice/server/BaseVoiceServer.java
@@ -216,7 +216,8 @@ public abstract class BaseVoiceServer extends BaseVoice implements PlasmoVoiceSe
             TOML.save(config, configFile);
 
             if (oldConfig != null) {
-                restartUdpServer = !config.host().equals(oldConfig.host());
+                restartUdpServer = !config.host().equals(oldConfig.host()) ||
+                        !config.voice().reusePort().equals(oldConfig.voice().reusePort());
             }
 
             ServerTranslator serverTranslator = getMinecraftServer().getServerTranslator();

--- a/server/common/src/main/java/su/plo/voice/server/config/VoiceServerConfig.java
+++ b/server/common/src/main/java/su/plo/voice/server/config/VoiceServerConfig.java
@@ -200,7 +200,7 @@ public final class VoiceServerConfig implements ServerConfig {
 
             @ConfigField(
                     comment =
-                            "Amount of sockets that'll be open with SO_REUSEPORT enabled\n\n" +
+                            "Amount of sockets that'll be open with SO_REUSEPORT enabled\n" +
                             "When set to 0, amount of channel will match amount of available CPU cores * 2"
             )
             private int sockets = 4;

--- a/server/common/src/main/java/su/plo/voice/server/config/VoiceServerConfig.java
+++ b/server/common/src/main/java/su/plo/voice/server/config/VoiceServerConfig.java
@@ -1,7 +1,6 @@
 package su.plo.voice.server.config;
 
 import com.google.common.collect.Maps;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -201,10 +200,10 @@ public final class VoiceServerConfig implements ServerConfig {
 
             @ConfigField(
                     comment =
-                            "Amount of sockets/threads that'll be open with SO_REUSEPORT enabled\n\n" +
-                            "0 means auto and will be derived from \"io.netty.eventLoopThreads\""
+                            "Amount of sockets that'll be open with SO_REUSEPORT enabled\n\n" +
+                            "When set to 0, amount of channel will match amount of available CPU cores * 2"
             )
-            private int channels = 0;
+            private int sockets = 4;
         }
 
         @Config

--- a/server/common/src/main/java/su/plo/voice/server/config/VoiceServerConfig.java
+++ b/server/common/src/main/java/su/plo/voice/server/config/VoiceServerConfig.java
@@ -1,6 +1,7 @@
 package su.plo.voice.server.config;
 
 import com.google.common.collect.Maps;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -168,6 +169,9 @@ public final class VoiceServerConfig implements ServerConfig {
         private @NotNull String clientModMinVersion = "2.0.0";
 
         @ConfigField
+        private ReusePort reusePort = new ReusePort();
+
+        @ConfigField
         private Proximity proximity = new Proximity();
 
         @ConfigField
@@ -180,6 +184,28 @@ public final class VoiceServerConfig implements ServerConfig {
                 comment = "Set custom weights for specific activations and source lines\nWeight determines display order in client menu and overlay (lower = higher position)"
         )
         private Weights weights = new Weights();
+
+        @Config
+        @Data
+        @Accessors(fluent = true)
+        public static class ReusePort implements ServerConfig.Voice.ReusePort {
+            @ConfigField(
+                    comment =
+                            "Enables SO_REUSEPORT\n" +
+                            "Instead of using one single thread for all incoming connections,\n" +
+                            "multiple sockets will be bound on the same port\n" +
+                            "and distribute connections between multiple worker threads\n" +
+                            "Requires Linux or macOS"
+            )
+            private boolean enabled = false;
+
+            @ConfigField(
+                    comment =
+                            "Amount of sockets/threads that'll be open with SO_REUSEPORT enabled\n\n" +
+                            "0 means auto and will be derived from \"io.netty.eventLoopThreads\""
+            )
+            private int channels = 0;
+        }
 
         @Config
         @Data

--- a/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpServer.java
+++ b/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpServer.java
@@ -25,12 +25,23 @@ import su.plo.voice.proto.packets.PacketDirection;
 import su.plo.voice.server.BaseVoiceServer;
 import su.plo.voice.socket.NettyExceptionHandler;
 import su.plo.voice.socket.NettyPacketUdpDecoder;
+import su.plo.voice.util.SystemPropertyKt;
 
 import java.net.InetSocketAddress;
 import java.util.Optional;
 import java.util.concurrent.ThreadFactory;
 
 public final class NettyUdpServer implements UdpServer {
+
+    // Spigot overwrites io.netty.eventLoopThreads with spigot.yml's netty-threads (default 4)
+    // so we have to avoid netty default amount of threads path
+    private static final int DEFAULT_THREADS = Math.max(
+            1,
+            SystemPropertyKt.getIntSystemProperty(
+                    "plasmovoice.udp_threads",
+                    Runtime.getRuntime().availableProcessors() * 2
+            )
+    );
 
     private final boolean useEpoll = System.getProperty("plasmovoice.use_epoll", "true").equals("true") &&
             Epoll.isAvailable();
@@ -50,8 +61,8 @@ public final class NettyUdpServer implements UdpServer {
         ThreadFactory factory = new DefaultThreadFactory("plasmo-voice-udp", Thread.MAX_PRIORITY);
 
         this.loopGroup = useEpoll
-                ? new EpollEventLoopGroup(0, factory)
-                : new NioEventLoopGroup(0, factory);
+                ? new EpollEventLoopGroup(DEFAULT_THREADS, factory)
+                : new NioEventLoopGroup(DEFAULT_THREADS, factory);
     }
 
     @Override

--- a/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpServer.java
+++ b/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpServer.java
@@ -6,7 +6,6 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
@@ -15,9 +14,9 @@ import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.channel.unix.UnixChannelOption;
 import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import io.netty.channel.unix.UnixChannelOption;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.jetbrains.annotations.NotNull;
 import su.plo.voice.BaseVoice;
@@ -92,14 +91,14 @@ public final class NettyUdpServer implements UdpServer {
 
         try {
             Channel firstChannel = null;
-            int channelCount = reusePortEnabled
-                    ? voiceServer.getConfig().voice().reusePort().channels()
+            int socketsAmount = reusePortEnabled
+                    ? voiceServer.getConfig().voice().reusePort().sockets()
                     : 1;
-            if (channelCount <= 0) {
-                channelCount = ((MultithreadEventLoopGroup) loopGroup).executorCount();
+            if (socketsAmount <= 0) {
+                socketsAmount = Runtime.getRuntime().availableProcessors() * 2;
             }
 
-            for (int i = 0; i < channelCount; i++) {
+            for (int i = 0; i < socketsAmount; i++) {
                 ChannelFuture channelFuture = bootstrap.bind(ip, port).sync();
                 Channel channel = channelFuture.channel();
                 channelGroup.add(channel);
@@ -114,10 +113,10 @@ public final class NettyUdpServer implements UdpServer {
                 keepAlive.start(firstChannel);
             }
 
-            if (reusePortEnabled && channelCount > 1) {
+            if (reusePortEnabled && socketsAmount > 1) {
                 BaseVoice.LOGGER.info(
                         "Bound {} {} UDP server instances with SO_REUSEPORT on {}",
-                        channelCount,
+                        socketsAmount,
                         channelClass.getSimpleName(),
                         socketAddress
                 );

--- a/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpServer.java
+++ b/server/common/src/main/java/su/plo/voice/server/socket/NettyUdpServer.java
@@ -6,6 +6,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
@@ -16,6 +17,7 @@ import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.channel.unix.UnixChannelOption;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.jetbrains.annotations.NotNull;
 import su.plo.voice.BaseVoice;
@@ -78,21 +80,56 @@ public final class NettyUdpServer implements UdpServer {
             }
         });
 
+        boolean reusePortEnabled = false;
+        if (useEpoll && voiceServer.getConfig().voice().reusePort().enabled()) {
+            try {
+                bootstrap.option(UnixChannelOption.SO_REUSEPORT, true);
+                reusePortEnabled = true;
+            } catch (Exception e) {
+                BaseVoice.LOGGER.warn("SO_REUSEPORT not supported on this platform, falling back to single channel");
+            }
+        }
+
         try {
-            ChannelFuture channelFuture = bootstrap.bind(ip, port).sync();
-            Channel channel = channelFuture.channel();
-            channelGroup.add(channel);
-            keepAlive.start(channel);
-            this.socketAddress = (InetSocketAddress) channelFuture.channel().localAddress();
+            Channel firstChannel = null;
+            int channelCount = reusePortEnabled
+                    ? voiceServer.getConfig().voice().reusePort().channels()
+                    : 1;
+            if (channelCount <= 0) {
+                channelCount = ((MultithreadEventLoopGroup) loopGroup).executorCount();
+            }
+
+            for (int i = 0; i < channelCount; i++) {
+                ChannelFuture channelFuture = bootstrap.bind(ip, port).sync();
+                Channel channel = channelFuture.channel();
+                channelGroup.add(channel);
+
+                if (firstChannel == null) {
+                    firstChannel = channel;
+                    this.socketAddress = (InetSocketAddress) channel.localAddress();
+                }
+            }
+
+            if (firstChannel != null) {
+                keepAlive.start(firstChannel);
+            }
+
+            if (reusePortEnabled && channelCount > 1) {
+                BaseVoice.LOGGER.info(
+                        "Bound {} {} UDP server instances with SO_REUSEPORT on {}",
+                        channelCount,
+                        channelClass.getSimpleName(),
+                        socketAddress
+                );
+            } else {
+                BaseVoice.LOGGER.info("{} UDP server is started on {}", channelClass.getSimpleName(), socketAddress);
+            }
         } catch (InterruptedException e) {
             stop();
-            return;
         } catch (Exception e) {
             stop();
             throw e;
         }
-
-        BaseVoice.LOGGER.info("{} UDP server is started on {}", channelClass.getSimpleName(), socketAddress);
     }
 
     @Override


### PR DESCRIPTION
final part of #503

reuseport is disabled by default and can be enabled in the config:
```toml
[voice.reuse_port] # [reuseport] in proxy config
# Enables SO_REUSEPORT
# Instead of using one single thread for all incoming connections,
# multiple sockets will be bound on the same port
# and distribute connections between multiple worker threads
# Requires Linux or macOS
enabled = true
# Amount of sockets that'll be open with SO_REUSEPORT enabled
# When set to 0, amount of channel will match amount of available CPU cores * 2
sockets = 8

```

also adds new `plasmovoice.udp_threads` system property to override amount of event loop threads, default it `Runtime.getRuntime().availableProcessors() * 2`
it is necessary due to spigot's behavior of overriding `io.netty.eventLoopThreads`, so it always uses the value from `spigot.yml` ignoring `io.netty.eventLoopThreads` completely